### PR TITLE
feat: 为 Linux Release 增加 RPM 包构建支持

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -1246,20 +1246,12 @@ jobs:
           dpkg-deb --build deb-pkg "zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.deb"
 
           # === rpm 包 ===
-          fpm -s dir -t rpm \
-            -n zedg \
-            -v "$CLEAN_VERSION" \
-            --iteration 1 \
-            --architecture x86_64 \
-            --description "Zed editor with globalization support." \
-            --url "https://github.com/x6nux/zed-globalization" \
-            --license "MIT" \
-            --maintainer "zed-globalization" \
-            --depends "glibc" \
-            --rpm-summary "Zed editor with globalization support" \
-            -C dist \
-            -p "zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.rpm" \
-            .
+          script/package-rpm.sh \
+            dist \
+            x86_64 \
+            "$BUILD_VERSION" \
+            "$LANG_LOWER" \
+            "zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.rpm"
 
       - name: 上传产物
         uses: actions/upload-artifact@v4
@@ -2145,20 +2137,12 @@ jobs:
           CTRL
           dpkg-deb --build deb-pkg "zedg-${LANG_LOWER}-linux-aarch64-${BUILD_VERSION}.deb"
 
-          fpm -s dir -t rpm \
-            -n zedg \
-            -v "$CLEAN_VERSION" \
-            --iteration 1 \
-            --architecture aarch64 \
-            --description "Zed editor with globalization support." \
-            --url "https://github.com/x6nux/zed-globalization" \
-            --license "MIT" \
-            --maintainer "zed-globalization" \
-            --depends "glibc" \
-            --rpm-summary "Zed editor with globalization support" \
-            -C dist \
-            -p "zedg-${LANG_LOWER}-linux-aarch64-${BUILD_VERSION}.rpm" \
-            .
+          script/package-rpm.sh \
+            dist \
+            aarch64 \
+            "$BUILD_VERSION" \
+            "$LANG_LOWER" \
+            "zedg-${LANG_LOWER}-linux-aarch64-${BUILD_VERSION}.rpm"
 
       - name: 上传产物
         uses: actions/upload-artifact@v4

--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -974,7 +974,7 @@ jobs:
       - name: 安装依赖
         run: |
           sudo apt update
-          sudo apt install -y build-essential pkg-config python3 libasound2-dev \
+          sudo apt install -y build-essential pkg-config python3 ruby ruby-dev rpm libasound2-dev \
             libx11-dev libx11-xcb-dev libxkbfile-dev libgtk-3-dev \
             libxcb-xinput-dev libwayland-dev libxkbcommon-dev \
             libxkbcommon-x11-dev libxcb1-dev libxcb-render0-dev \
@@ -982,6 +982,7 @@ jobs:
             libxcb-randr0-dev libxcb-keysyms1-dev libxcb-util-dev \
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
             libssl-dev libudev-dev libclang-dev clang cmake mold
+          sudo gem install --no-document fpm
           echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
 
       - name: 克隆 Zed 源码并检出 Tag
@@ -1244,6 +1245,22 @@ jobs:
           CTRL
           dpkg-deb --build deb-pkg "zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.deb"
 
+          # === rpm 包 ===
+          fpm -s dir -t rpm \
+            -n zedg \
+            -v "$CLEAN_VERSION" \
+            --iteration 1 \
+            --architecture x86_64 \
+            --description "Zed editor with globalization support." \
+            --url "https://github.com/x6nux/zed-globalization" \
+            --license "MIT" \
+            --maintainer "zed-globalization" \
+            --depends "glibc" \
+            --rpm-summary "Zed editor with globalization support" \
+            -C dist \
+            -p "zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.rpm" \
+            .
+
       - name: 上传产物
         uses: actions/upload-artifact@v4
         with:
@@ -1251,6 +1268,7 @@ jobs:
           path: |
             zedg-${{ env.LANG_LOWER }}-linux-x86_64-${{ env.BUILD_VERSION }}.tar.gz
             zedg-${{ env.LANG_LOWER }}-linux-x86_64-${{ env.BUILD_VERSION }}.deb
+            zedg-${{ env.LANG_LOWER }}-linux-x86_64-${{ env.BUILD_VERSION }}.rpm
 
   # ===========================================================================
   # 5a. macOS aarch64 编译（Apple Silicon）
@@ -1862,7 +1880,7 @@ jobs:
       - name: 安装依赖
         run: |
           sudo apt update
-          sudo apt install -y build-essential pkg-config python3 libasound2-dev \
+          sudo apt install -y build-essential pkg-config python3 ruby ruby-dev rpm libasound2-dev \
             libx11-dev libx11-xcb-dev libxkbfile-dev libgtk-3-dev \
             libxcb-xinput-dev libwayland-dev libxkbcommon-dev \
             libxkbcommon-x11-dev libxcb1-dev libxcb-render0-dev \
@@ -1870,6 +1888,7 @@ jobs:
             libxcb-randr0-dev libxcb-keysyms1-dev libxcb-util-dev \
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
             libssl-dev libudev-dev libclang-dev clang cmake mold
+          sudo gem install --no-document fpm
           echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
 
       - name: 克隆 Zed 源码并检出 Tag
@@ -2126,6 +2145,21 @@ jobs:
           CTRL
           dpkg-deb --build deb-pkg "zedg-${LANG_LOWER}-linux-aarch64-${BUILD_VERSION}.deb"
 
+          fpm -s dir -t rpm \
+            -n zedg \
+            -v "$CLEAN_VERSION" \
+            --iteration 1 \
+            --architecture aarch64 \
+            --description "Zed editor with globalization support." \
+            --url "https://github.com/x6nux/zed-globalization" \
+            --license "MIT" \
+            --maintainer "zed-globalization" \
+            --depends "glibc" \
+            --rpm-summary "Zed editor with globalization support" \
+            -C dist \
+            -p "zedg-${LANG_LOWER}-linux-aarch64-${BUILD_VERSION}.rpm" \
+            .
+
       - name: 上传产物
         uses: actions/upload-artifact@v4
         with:
@@ -2133,6 +2167,7 @@ jobs:
           path: |
             zedg-${{ env.LANG_LOWER }}-linux-aarch64-${{ env.BUILD_VERSION }}.tar.gz
             zedg-${{ env.LANG_LOWER }}-linux-aarch64-${{ env.BUILD_VERSION }}.deb
+            zedg-${{ env.LANG_LOWER }}-linux-aarch64-${{ env.BUILD_VERSION }}.rpm
 
   # ===========================================================================
   # 6. 正式发布
@@ -2217,8 +2252,10 @@ jobs:
           mv "artifacts/zed-windows-msi/zedg-${LANG_LOWER}-windows-aarch64-${BUILD_VERSION}.msi" release-dist/ || echo "No Windows aarch64 MSI"
           mv "artifacts/zed-linux/zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.tar.gz" release-dist/ || echo "No Linux x86_64 tar artifact"
           mv "artifacts/zed-linux/zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.deb" release-dist/ || echo "No Linux x86_64 deb artifact"
+          mv "artifacts/zed-linux/zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.rpm" release-dist/ || echo "No Linux x86_64 rpm artifact"
           mv "artifacts/zed-linux-arm64/zedg-${LANG_LOWER}-linux-aarch64-${BUILD_VERSION}.tar.gz" release-dist/ || echo "No Linux ARM64 tar artifact"
           mv "artifacts/zed-linux-arm64/zedg-${LANG_LOWER}-linux-aarch64-${BUILD_VERSION}.deb" release-dist/ || echo "No Linux ARM64 deb artifact"
+          mv "artifacts/zed-linux-arm64/zedg-${LANG_LOWER}-linux-aarch64-${BUILD_VERSION}.rpm" release-dist/ || echo "No Linux ARM64 rpm artifact"
           mv "artifacts/zed-macos/zedg-${LANG_LOWER}-macos-universal-${BUILD_VERSION}.dmg" release-dist/ || echo "No macOS Universal artifact"
           mv "artifacts/zed-macos/zedg-${LANG_LOWER}-macos-aarch64-${BUILD_VERSION}.dmg" release-dist/ || echo "No macOS aarch64 artifact"
           mv "artifacts/zed-macos/zedg-${LANG_LOWER}-macos-x86_64-${BUILD_VERSION}.dmg" release-dist/ || echo "No macOS x86_64 artifact"

--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@
 | Windows (ARM64) | `zedg-zh-cn-windows-aarch64-*.zip` | 解压后运行 `ZedG.exe` |
 | Linux (x64) | `zedg-zh-cn-linux-x86_64-*.tar.gz` | 解压到 `/usr/local` |
 | Linux (x64 deb) | `zedg-zh-cn-linux-x86_64-*.deb` | `sudo dpkg -i *.deb` |
+| Linux (x64 rpm) | `zedg-zh-cn-linux-x86_64-*.rpm` | `sudo dnf install ./zedg-*.rpm` |
 | Linux (ARM64) | `zedg-zh-cn-linux-aarch64-*.tar.gz` | 解压到 `/usr/local` |
 | Linux (ARM64 deb) | `zedg-zh-cn-linux-aarch64-*.deb` | `sudo dpkg -i *.deb` |
+| Linux (ARM64 rpm) | `zedg-zh-cn-linux-aarch64-*.rpm` | `sudo dnf install ./zedg-*.rpm` |
 
 ### macOS 安装
 
@@ -97,6 +99,22 @@ scoop install zedg-preview
 > # 关闭
 > schtasks /delete /tn "ZedGUpdate" /f
 > ```
+
+### Fedora / RHEL 安装
+
+从 Releases 下载对应架构的 RPM 包后安装：
+
+```bash
+sudo dnf install ./zedg-zh-cn-linux-x86_64-*.rpm
+```
+
+ARM64 设备请下载并安装 `zedg-zh-cn-linux-aarch64-*.rpm`。
+
+卸载：
+
+```bash
+sudo dnf remove zedg
+```
 
 ## 特性
 

--- a/script/package-rpm.sh
+++ b/script/package-rpm.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "$#" -ne 5 ]; then
+  echo "Usage: $0 <staging_dir> <arch> <version> <lang_lower> <output_path>" >&2
+  exit 2
+fi
+
+STAGING_DIR="$1"
+ARCH="$2"
+VERSION="$3"
+LANG_LOWER="$4"
+OUTPUT_PATH="$5"
+
+if [ ! -d "$STAGING_DIR" ]; then
+  echo "staging_dir does not exist: $STAGING_DIR" >&2
+  exit 1
+fi
+
+case "$ARCH" in
+  x86_64|aarch64) ;;
+  *)
+    echo "unsupported RPM architecture: $ARCH" >&2
+    exit 1
+    ;;
+esac
+
+CLEAN_VERSION="${VERSION#v}"
+
+fpm -s dir -t rpm \
+  -n zedg \
+  -v "$CLEAN_VERSION" \
+  --iteration 1 \
+  --architecture "$ARCH" \
+  --description "Zed editor with globalization support." \
+  --url "https://github.com/x6nux/zed-globalization" \
+  --license "MIT" \
+  --maintainer "zed-globalization" \
+  --depends "glibc" \
+  --rpm-summary "Zed editor with globalization support" \
+  -C "$STAGING_DIR" \
+  -p "$OUTPUT_PATH" \
+  .


### PR DESCRIPTION
## 变更概述

- 为 Linux x86_64 和 aarch64 Release 构建增加 RPM 包产物。
- README 增加 RPM 下载项和 Fedora / RHEL 的 `dnf` 安装说明。

## 主要修改

- 新增 `script/package-rpm.sh`，统一封装 `fpm` 生成 RPM 的逻辑。
- Linux x86_64 和 aarch64 构建 job 复用现有 `dist/` staging 目录生成 `.rpm`。
- Linux 构建 job 上传 `.tar.gz`、`.deb`、`.rpm` 三类产物。
- Release job 将 x86_64 和 aarch64 的 `.rpm` 移入 `release-dist`，随 Release assets 和校验和一起发布。
- README 的 Release 下载表增加 x64 / ARM64 RPM 行，并新增 Fedora / RHEL 安装和卸载示例。

## 测试情况

- 已运行：`cat /etc/os-release`，确认本地系统为 Fedora Linux 43（KDE Plasma Desktop Edition）。
- 已运行：`command -v dnf || true`，输出 `/usr/bin/dnf`。
- 已运行：`command -v apt || true`，无输出，确认本地没有 `apt`。
- 已运行：`sudo dnf install -y ruby ruby-devel rpm-build rpmdevtools rubygems`，未完成；当前会话无法输入 sudo 密码，输出 `sudo: 需要密码`。
- 已运行：`sudo gem install --no-document fpm`，未完成；当前会话无法输入 sudo 密码，输出 `sudo: 需要密码`。
- 已运行：`ruby --version`，输出 `ruby 3.4.8 (2025-12-17 revision 995b59f666) +PRISM [x86_64-linux]`。
- 已运行：`gem --version`，输出 `4.0.10`。
- 已运行：`fpm --version`，输出 `1.17.0`。
- 已运行：`rpm --version`，输出 `RPM 版本 6.0.1`。
- 已运行：`rpmbuild --version`，输出 `RPM 版本 6.0.1`。
- 已运行最小 RPM 打包测试：创建临时 staging 目录，放入 `/usr/bin/zedg` 测试脚本、`/usr/share/applications/dev.zed.ZedG.desktop` 和 `/usr/share/icons/hicolor/512x512/apps/zedg.png` 占位文件，并通过 `script/package-rpm.sh` 生成 `zedg-test.rpm`。
- 已运行：`rpm -qpi zedg-test.rpm`，可读取包信息，包名为 `zedg`，版本为 `0.0.1`，架构为 `x86_64`。
- 已运行：`rpm -qlp zedg-test.rpm`，确认包内包含 `/usr/bin/zedg`、desktop entry 和图标路径。
- 已运行：`python -c "import yaml; yaml.safe_load(open('.github/workflows/02-build.yml', encoding='utf-8')); print('YAML syntax OK')"`，输出 `YAML syntax OK`。
- 已运行：`git diff --check`，无输出，未发现空白错误。
- 已运行：`actionlint --version`，输出 `v1.7.12`。
- 已运行：`actionlint .github/workflows/02-build.yml`，无输出，未发现问题。
- 未运行：完整 GitHub Actions Linux 构建，需在 PR CI 中验证实际 Zed 编译和正式 Release 产物上传。

## 关联 Issue

Closes #14

## 注意事项 / 风险

- GitHub Actions runner 使用 `ubuntu-latest` / `ubuntu-24.04-arm`，workflow 中继续使用 `apt` 安装 Ruby、RPM 工具和 `fpm`。
- 本地验证环境为 Fedora，因此本地依赖安装命令使用 `dnf`；其中需要 sudo 的安装步骤因当前会话无法输入密码未完成，但本机已有 `ruby`、`gem`、`fpm`、`rpm` 和 `rpmbuild`，最小 RPM 打包测试已完成。
- RPM 产物复用现有 tar.gz 的 `dist/` staging 目录，包内文件布局与现有 Linux tar.gz 保持一致。
