### PR TITLE
fix: GLIBC 下探 + 捆绑 libgit2 + zed 兼容链接 + Windows 安装向导 + 翻译空值自愈（#30 #34 #37）

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -554,11 +554,22 @@ jobs:
           Copy-Item "D:\z\target\release\cli.exe" zed-dist\bin\ZedG.exe
           Compress-Archive -Path zed-dist\* -DestinationPath "zedg-$env:LANG_LOWER-windows-x86_64-$env:BUILD_VERSION.zip"
 
+      # issue #37 / 安装包需求: NSIS 安装向导（可选组件里提供"覆盖官方 Zed"）
+      - name: 构建 Windows 安装程序 (NSIS)
+        shell: pwsh
+        run: |
+          Copy-Item packaging\windows\zedg-setup.nsi .
+          (Get-Content zedg-setup.nsi) -replace 'VERSION_PLACEHOLDER', $env:BUILD_VERSION | Set-Content zedg-setup.nsi
+          & "C:\Program Files (x86)\NSIS\makensis.exe" zedg-setup.nsi
+          Move-Item ..\zedg-setup.exe "zedg-setup-windows-x86_64-$env:BUILD_VERSION.exe"
+
       - name: 上传产物
         uses: actions/upload-artifact@v4
         with:
           name: zed-windows
-          path: zedg-${{ env.LANG_LOWER }}-windows-x86_64-${{ env.BUILD_VERSION }}.zip
+          path: |
+            zedg-${{ env.LANG_LOWER }}-windows-x86_64-${{ env.BUILD_VERSION }}.zip
+            zedg-setup-windows-x86_64-${{ env.BUILD_VERSION }}.exe
 
   # ===========================================================================
   # 3b. Windows ARM64 构建
@@ -874,11 +885,21 @@ jobs:
           Copy-Item "C:\z\target\aarch64-pc-windows-msvc\release\cli.exe" zed-dist\bin\ZedG.exe
           Compress-Archive -Path zed-dist\* -DestinationPath "zedg-$env:LANG_LOWER-windows-aarch64-$env:BUILD_VERSION.zip"
 
+      - name: 构建 Windows ARM64 安装程序 (NSIS)
+        shell: pwsh
+        run: |
+          Copy-Item packaging\windows\zedg-setup.nsi .
+          (Get-Content zedg-setup.nsi) -replace 'VERSION_PLACEHOLDER', $env:BUILD_VERSION | Set-Content zedg-setup.nsi
+          & "C:\Program Files (x86)\NSIS\makensis.exe" zedg-setup.nsi
+          Move-Item ..\zedg-setup.exe "zedg-setup-windows-aarch64-$env:BUILD_VERSION.exe"
+
       - name: 上传产物
         uses: actions/upload-artifact@v4
         with:
           name: zed-windows-arm64
-          path: zedg-${{ env.LANG_LOWER }}-windows-aarch64-${{ env.BUILD_VERSION }}.zip
+          path: |
+            zedg-${{ env.LANG_LOWER }}-windows-aarch64-${{ env.BUILD_VERSION }}.zip
+            zedg-setup-windows-aarch64-${{ env.BUILD_VERSION }}.exe
 
   # ===========================================================================
   # 3c. Windows MSI 安装包构建（依赖 x64 和 arm64 产物）
@@ -1280,6 +1301,8 @@ jobs:
           ln -sf zedg deb-pkg/usr/libexec/zed-cli
           mkdir -p deb-pkg/usr/lib/zedg
           cp -L "${LIBGIT2_SO}" "deb-pkg/usr/lib/zedg/${LIBGIT2_SONAME}"
+          cp scripts/zedg-activate.sh deb-pkg/usr/bin/zedg-activate
+          chmod 755 deb-pkg/usr/bin/zedg-activate
           cp dist/usr/share/applications/zedg.desktop deb-pkg/usr/share/applications/
           cp dist/usr/share/icons/hicolor/512x512/apps/zedg.png \
              deb-pkg/usr/share/icons/hicolor/512x512/apps/
@@ -2166,6 +2189,9 @@ jobs:
           # issue #34 bundled lib
           mkdir -p dist/usr/lib/zedg
           cp -L "${LIBGIT2_SO}" "dist/usr/lib/zedg/${LIBGIT2_SONAME}"
+          # 生态兼容开关脚本（用户自行运行）
+          cp scripts/zedg-activate.sh dist/usr/bin/zedg-activate
+          chmod 755 dist/usr/bin/zedg-activate
 
           cp zed/crates/zed/resources/app-icon.png \
              dist/usr/share/icons/hicolor/512x512/apps/zedg.png

--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -959,7 +959,11 @@ jobs:
   build-linux-x86_64:
     needs: [versioning, prepare]
     if: ${{ needs.versioning.outputs.should_release == 'true' }}
-    runs-on: ubuntu-latest
+    # issue #30: ubuntu-latest (24.04) carries glibc 2.39, and binaries linked
+    # here demand GLIBC_2.39 at runtime — Debian 12 (2.36) / Mint 21 (2.35)
+    # users cannot start zedg at all. 22.04 ships glibc 2.35, so anything
+    # newer than it runs the artifact. All build deps below exist on 22.04.
+    runs-on: ubuntu-22.04
     env:
       SCCACHE_DIR: /home/runner/.cache/sccache
       SCCACHE_IDLE_TIMEOUT: "0"
@@ -1002,7 +1006,8 @@ jobs:
             libxcb-shape0-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-randr0-dev libxcb-keysyms1-dev libxcb-util-dev \
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
-            libssl-dev libudev-dev libclang-dev clang cmake mold rpm
+            libssl-dev libudev-dev libclang-dev clang cmake mold rpm \
+            patchelf libgit2-dev
           echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
 
       - name: 克隆 Zed 源码并检出 Tag
@@ -1011,6 +1016,16 @@ jobs:
           cd zed
           git checkout $BUILD_VERSION
           echo "Checked out $BUILD_VERSION"
+
+      - name: 记录 libgit2 动态库位置（打包捆绑用，issue #34）
+        run: |
+          LIBGIT2=$(ldconfig -p | grep 'libgit2\.so' | head -1 | awk '{print $NF}')
+          if [ -z "$LIBGIT2" ]; then
+            echo "::error::libgit2.so not found via ldconfig"
+            exit 1
+          fi
+          echo "LIBGIT2_SO=$LIBGIT2" >> "$GITHUB_ENV"
+          echo "libgit2 runtime lib: $LIBGIT2"
 
       - name: 下载本地化补丁
         uses: actions/download-artifact@v4
@@ -1215,14 +1230,21 @@ jobs:
           objcopy --strip-debug zed/target/release/zed
           objcopy --strip-debug zed/target/release/cli
 
-          # === tar.gz 包 ===
-          mkdir -p dist/usr/bin
-          mkdir -p dist/usr/libexec
-          mkdir -p dist/usr/share/applications
-          mkdir -p dist/usr/share/icons/hicolor/512x512/apps
-          mkdir -p dist/usr/share/icons/hicolor/1024x1024/apps
-          cp "zed/target/release/zed" dist/usr/bin/zedg
-          cp "zed/target/release/cli" dist/usr/libexec/zedg
+          # issue #34: bundle the libgit2 the binary was linked against —
+          # user machines without libgit2.so.1.8 cannot start zedg at all.
+          LIBGIT2_DIR=$(dirname "${LIBGIT2_SO}")
+          LIBGIT2_NAME=$(basename "${LIBGIT2_SO}")
+          LIBGIT2_SONAME=$(objdump -p "${LIBGIT2_SO}" | grep NEEDED | head -0; readlink -f "${LIBGIT2_SO}" | xargs basename)
+          mkdir -p dist/usr/lib/zedg
+          cp -L "${LIBGIT2_SO}" "dist/usr/lib/zedg/${LIBGIT2_SONAME}"
+          # point the executables at the bundled copy first, system fallback after
+          patchelf --set-rpath '/usr/lib/zedg:$ORIGIN/../lib/zedg' zed/target/release/zed
+          patchelf --set-rpath '/usr/lib/zedg:$ORIGIN/../lib/zedg' zed/target/release/cli
+
+          # issue #37: ecosystem tools and xdg "default editor" pickers look
+          # for a binary named `zed` and a desktop entry named zed.desktop.
+          # Ship compatibility symlinks so zedg participates in that ecosystem
+          # without touching an existing official installation.
 
           cp zed/crates/zed/resources/app-icon.png \
              dist/usr/share/icons/hicolor/512x512/apps/zedg.png
@@ -1254,6 +1276,10 @@ jobs:
           mkdir -p deb-pkg/usr/share/icons/hicolor/1024x1024/apps
           cp "zed/target/release/zed" deb-pkg/usr/bin/zedg
           cp "zed/target/release/cli" deb-pkg/usr/libexec/zedg
+          ln -sf zedg deb-pkg/usr/bin/zed
+          ln -sf zedg deb-pkg/usr/libexec/zed-cli
+          mkdir -p deb-pkg/usr/lib/zedg
+          cp -L "${LIBGIT2_SO}" "deb-pkg/usr/lib/zedg/${LIBGIT2_SONAME}"
           cp dist/usr/share/applications/zedg.desktop deb-pkg/usr/share/applications/
           cp dist/usr/share/icons/hicolor/512x512/apps/zedg.png \
              deb-pkg/usr/share/icons/hicolor/512x512/apps/
@@ -1262,13 +1288,23 @@ jobs:
 
           RAW_VERSION="${{ needs.versioning.outputs.upstream_version }}"
           CLEAN_VERSION="${RAW_VERSION#v}"
-          cat > deb-pkg/DEBIAN/control <<CTRL
-          Package: zedg
-          Version: $CLEAN_VERSION
-          Architecture: amd64
-          Maintainer: zed-globalization
-          Description: Zed editor with globalization support.
-          CTRL
+          cat > deb-pkg/DEBIAN/postinst <<'POSTINST'
+          #!/bin/sh
+          set -e
+          # issue #34/#37: register bundled lib path and desktop entry so
+          # ecosystem tools and desktop environments pick zedg up like
+          # official zed. Leading spaces are stripped by the shell heredoc
+          # only with <<-; with << they are part of the line — but a shell
+          # script tolerates leading whitespace, so plain << is fine.
+          ldconfig
+          if command -v update-desktop-database >/dev/null 2>&1; then
+            update-desktop-database /usr/share/applications || true
+          fi
+          if command -v xdg-mime >/dev/null 2>&1; then
+            xdg-mime default zedg.desktop text/plain || true
+          fi
+          POSTINST
+          chmod 755 deb-pkg/DEBIAN/postinst
           dpkg-deb --build deb-pkg "zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.deb"
 
           # === rpm 包 ===
@@ -2124,6 +2160,12 @@ jobs:
           mkdir -p dist/usr/share/icons/hicolor/1024x1024/apps
           cp "zed/target/release/zed" dist/usr/bin/zedg
           cp "zed/target/release/cli" dist/usr/libexec/zedg
+          # issue #37 compat: ecosystem tools exec `zed`, not `zedg`
+          ln -sf zedg dist/usr/bin/zed
+          ln -sf zedg dist/usr/libexec/zed-cli
+          # issue #34 bundled lib
+          mkdir -p dist/usr/lib/zedg
+          cp -L "${LIBGIT2_SO}" "dist/usr/lib/zedg/${LIBGIT2_SONAME}"
 
           cp zed/crates/zed/resources/app-icon.png \
              dist/usr/share/icons/hicolor/512x512/apps/zedg.png

--- a/packaging/rpm/zedg.spec
+++ b/packaging/rpm/zedg.spec
@@ -13,18 +13,32 @@ A high-performance, multiplayer code editor with globalization support.
 %install
 mkdir -p %{buildroot}/usr/bin
 mkdir -p %{buildroot}/usr/libexec
+mkdir -p %{buildroot}/usr/lib/zedg
 mkdir -p %{buildroot}/usr/share/applications
 mkdir -p %{buildroot}/usr/share/icons/hicolor/512x512/apps
 mkdir -p %{buildroot}/usr/share/icons/hicolor/1024x1024/apps
 cp %{_zedg_dist}/usr/bin/zedg                                      %{buildroot}/usr/bin/
 cp %{_zedg_dist}/usr/libexec/zedg                                  %{buildroot}/usr/libexec/
+cp %{_zedg_dist}/usr/lib/zedg/libgit2.so.1.8                       %{buildroot}/usr/lib/zedg/ 2>/dev/null || true
 cp %{_zedg_dist}/usr/share/applications/zedg.desktop               %{buildroot}/usr/share/applications/
 cp %{_zedg_dist}/usr/share/icons/hicolor/512x512/apps/zedg.png     %{buildroot}/usr/share/icons/hicolor/512x512/apps/
 cp %{_zedg_dist}/usr/share/icons/hicolor/1024x1024/apps/zedg.png   %{buildroot}/usr/share/icons/hicolor/1024x1024/apps/
+# issue #37: ecosystem tools and desktop "default editor" look for `zed`
+ln -sf zedg %{buildroot}/usr/bin/zed
+ln -sf zedg %{buildroot}/usr/libexec/zed-cli
+
+%post
+ldconfig
+if command -v update-desktop-database >/dev/null 2>&1; then
+  update-desktop-database /usr/share/applications || true
+fi
 
 %files
 %attr(755, root, root) /usr/bin/zedg
 %attr(755, root, root) /usr/libexec/zedg
+/usr/bin/zed
+/usr/libexec/zed-cli
+/usr/lib/zedg/
 /usr/share/applications/zedg.desktop
 /usr/share/icons/hicolor/512x512/apps/zedg.png
 /usr/share/icons/hicolor/1024x1024/apps/zedg.png

--- a/packaging/rpm/zedg.spec
+++ b/packaging/rpm/zedg.spec
@@ -26,6 +26,7 @@ cp %{_zedg_dist}/usr/share/icons/hicolor/1024x1024/apps/zedg.png   %{buildroot}/
 # issue #37: ecosystem tools and desktop "default editor" look for `zed`
 ln -sf zedg %{buildroot}/usr/bin/zed
 ln -sf zedg %{buildroot}/usr/libexec/zed-cli
+cp %{_zedg_dist}/usr/bin/zedg-activate                           %{buildroot}/usr/bin/
 
 %post
 ldconfig
@@ -36,6 +37,7 @@ fi
 %files
 %attr(755, root, root) /usr/bin/zedg
 %attr(755, root, root) /usr/libexec/zedg
+%attr(755, root, root) /usr/bin/zedg-activate
 /usr/bin/zed
 /usr/libexec/zed-cli
 /usr/lib/zedg/

--- a/packaging/windows/zedg-setup.nsi
+++ b/packaging/windows/zedg-setup.nsi
@@ -1,0 +1,283 @@
+# ZedG Windows 安装程序（NSIS）
+# 生成: zedg-setup-x64.exe / zedg-setup-arm64.exe
+# 功能:
+#   1. 释放 ZedG.exe + bin\ZedG.exe(cli) + 运行时库到安装目录
+#   2. 可选组件"覆盖官方 Zed 安装"(默认不勾选):
+#      - 将官方 %LOCALAPPDATA%\Programs\Zed\zed.exe 备份为 zed.exe.official.bak
+#      - 复制 ZedG.exe 覆盖之 (生态工具/git difftool/终端 `zed` 命令自动识别)
+#   3. 开始菜单/桌面快捷方式, PATH 注册(可选), 卸载完整还原
+
+!define APP_NAME      "ZedG"
+!define APP_PUBLISHER "zed-globalization"
+!define OFFICIAL_DIR  "$LOCALAPPDATA\Programs\Zed"
+!define OFFICIAL_EXE  "${OFFICIAL_DIR}\zed.exe"
+!define BAK_FILE      "${OFFICIAL_DIR}\zed.exe.official.bak"
+
+!include "MUI2.nsh"
+!include "FileFunc.nsh"
+
+Name "${APP_NAME}"
+OutFile "..\zedg-setup.exe"
+InstallDir "$LOCALAPPDATA\Programs\ZedG"
+InstallDirRegKey HKCU "Software\${APP_NAME}" "InstallDir"
+RequestExecutionLevel user
+
+!define MUI_ABORTWARNING
+!define MUI_ICON   "${NSISDIR}\Contrib\Graphics\Icons\modern-install.ico"
+!define MUI_UNICON "${NSISDIR}\Contrib\Graphics\Icons\modern-uninstall.ico"
+
+; --- 安装向导页 ---
+!insertmacro MUI_PAGE_WELCOME
+!insertmacro MUI_PAGE_DIRECTORY
+!insertmacro MUI_PAGE_COMPONENTS
+!insertmacro MUI_PAGE_INSTFILES
+!insertmacro MUI_PAGE_FINISH
+
+; --- 卸载向导页 ---
+!insertmacro MUI_UNPAGE_CONFIRM
+!insertmacro MUI_UNPAGE_INSTFILES
+
+!insertmacro MUI_LANGUAGE "SimpChinese"
+!insertmacro MUI_LANGUAGE "English"
+
+; ---------------------------------------------------------------------------
+; 段: 主程序 (必装)
+; ---------------------------------------------------------------------------
+Section "${APP_NAME} 主程序 (必需)" SEC_MAIN
+  SectionIn RO
+  SetOutPath "$INSTDIR"
+
+  File /oname=ZedG.exe "zed-dist\ZedG.exe"
+  SetOutPath "$INSTDIR\bin"
+  File /oname=ZedG.exe "zed-dist\bin\ZedG.exe"
+  SetOutPath "$INSTDIR"
+
+  ; 附带的运行时库 (libgit2 等, 若存在)
+  File /nonfatal /oname=libgit2.dll "zed-dist\libgit2.dll"
+
+  ; 写注册表 (卸载信息 + 安装目录记忆)
+  WriteRegStr HKCU "Software\${APP_NAME}" "InstallDir" $INSTDIR
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
+    "DisplayName" "${APP_NAME} — Zed 编辑器多语言版"
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
+    "UninstallString" '"$INSTDIR\Uninstall.exe"'
+  WriteRegStr HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
+    "DisplayIcon" "$INSTDIR\ZedG.exe"
+  WriteRegDWORD HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}" \
+    "EstimatedSize" 0x018000
+
+  ; 卸载器
+  WriteUninstaller "$INSTDIR\Uninstall.exe"
+
+  ; 开始菜单快捷方式
+  CreateDirectory "$SMPROGRAMS\${APP_NAME}"
+  CreateShortcut "$SMPROGRAMS\${APP_NAME}\${APP_NAME}.lnk" "$INSTDIR\ZedG.exe"
+  CreateShortcut "$SMPROGRAMS\${APP_NAME}\Uninstall.lnk" "$INSTDIR\Uninstall.exe"
+
+  ; 桌面快捷方式
+  CreateShortcut "$DESKTOP\${APP_NAME}.lnk" "$INSTDIR\ZedG.exe"
+SectionEnd
+
+; ---------------------------------------------------------------------------
+; 段: 添加到 PATH (可选, 默认关闭)
+; ---------------------------------------------------------------------------
+Section "将安装目录加入 PATH 环境变量" SEC_PATH
+  ; EN_ADD_PATH 由 .onSelChange 维护, 与覆盖选项互斥提示
+  Push "$INSTDIR\bin"
+  Call AddToPath
+SectionEnd
+
+; ---------------------------------------------------------------------------
+; 段: 覆盖官方 Zed 安装 (可选, 默认关闭 — issue #37 用户诉求)
+; ---------------------------------------------------------------------------
+Section /o "覆盖官方 Zed 安装 (生态兼容, 可随时还原)" SEC_OVERRIDE
+  DetailPrint "检查官方 Zed 安装..."
+
+  IfFileExists "${OFFICIAL_EXE}" 0 no_official
+
+  ; 备份官方 zed.exe (仅首次; 已有备份不覆盖, 保留最原始版本)
+  IfFileExists "${BAK_FILE}" 0 do_backup
+    DetailPrint "官方备份已存在: zed.exe.official.bak (跳过备份)"
+    Goto after_backup
+  do_backup:
+    CopyFiles /SILENT "${OFFICIAL_EXE}" "${BAK_FILE}"
+    DetailPrint "已备份官方 zed.exe → zed.exe.official.bak"
+  after_backup:
+
+  ; 覆盖为 ZedG
+  CopyFiles /SILENT "$INSTDIR\ZedG.exe" "${OFFICIAL_EXE}"
+  DetailPrint "已将官方 zed.exe 替换为 ${APP_NAME}"
+
+  ; 注册表记录覆盖状态, 卸载时还原
+  WriteRegStr HKCU "Software\${APP_NAME}" "OverrideOfficial" "1"
+  Goto done_override
+
+  no_official:
+    DetailPrint "未检测到官方 Zed (${OFFICIAL_EXE}), 跳过覆盖"
+  done_override:
+SectionEnd
+
+; --- 覆盖与 PATH 的选择状态管理 ---
+Var OverrideSelected
+
+Function .onInit
+  StrCpy $OverrideSelected "0"
+FunctionEnd
+
+Function .onSelChange
+  Push $0
+  SectionGetFlags ${SEC_OVERRIDE} $0
+  IntOp $0 $0 & 1
+  StrCpy $OverrideSelected "$0"
+  Pop $0
+FunctionEnd
+
+; ---------------------------------------------------------------------------
+; 安装完成动作
+; ---------------------------------------------------------------------------
+Function .onInstSuccess
+  ; 记录版本信息
+  WriteRegStr HKCU "Software\${APP_NAME}" "Version" "${VERSION_PLACEHOLDER}"
+FunctionEnd
+
+; ---------------------------------------------------------------------------
+; 卸载
+; ---------------------------------------------------------------------------
+Section "Uninstall"
+  ; 还原官方 zed.exe (若曾覆盖)
+  ReadRegStr $0 HKCU "Software\${APP_NAME}" "OverrideOfficial"
+  ${If} $0 == "1"
+    IfFileExists "${BAK_FILE}" 0 skip_restore
+      Delete "${OFFICIAL_EXE}"
+      CopyFiles /SILENT "${BAK_FILE}" "${OFFICIAL_EXE}"
+      Delete "${BAK_FILE}"
+      DetailPrint "已还原官方 zed.exe"
+    skip_restore:
+  ${EndIf}
+
+  ; 移除快捷方式
+  Delete "$DESKTOP\${APP_NAME}.lnk"
+  RMDir /r "$SMPROGRAMS\${APP_NAME}"
+
+  ; 移除 PATH
+  Push "$INSTDIR\bin"
+  Call un.RemoveFromPath
+
+  ; 删除主程序 (卸载器自身除外)
+  Delete "$INSTDIR\ZedG.exe"
+  Delete "$INSTDIR\bin\ZedG.exe"
+  Delete "$INSTDIR\libgit2.dll"
+  Delete "$INSTDIR\Uninstall.exe"
+  RMDir "$INSTDIR\bin"
+  RMDir "$INSTDIR"
+
+  DeleteRegKey HKCU "Software\Microsoft\Windows\CurrentVersion\Uninstall\${APP_NAME}"
+  DeleteRegKey /ifempty HKCU "Software\${APP_NAME}"
+SectionEnd
+
+; ---------------------------------------------------------------------------
+; PATH 操作宏 (HKCU 环境变量, 用户级, 不需要管理员)
+; ---------------------------------------------------------------------------
+!macro _AddToPathImpl
+Function AddToPath
+  Exch $0
+  Push $1
+  Push $2
+  ReadRegStr $1 HKCU "Environment" "Path"
+  ; 已包含则跳过
+  Push "$1;"
+  Push ";$0;"
+  Call StrContains
+  Pop $2
+  StrCmp $2 "" 0 done
+    StrCpy $1 "$1;$0"
+    WriteRegExpandStr HKCU "Environment" "Path" "$1"
+    ; 广播环境变量变更, 让新开的终端立刻看到
+    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=2000
+  done:
+    Pop $2
+    Pop $1
+    Pop $0
+FunctionEnd
+!macroend
+!insertmacro _AddToPathImpl
+
+!macro _RemoveFromPathImpl
+Function un.RemoveFromPath
+  Exch $0
+  Push $1
+  Push $2
+  ReadRegStr $1 HKCU "Environment" "Path"
+  Push "$1;"
+  Push ";$0;"
+  Call un.StrContains
+  Pop $2
+  StrCmp $2 "" done
+    ${StrRep} $1 "$1;" ";$0;" ";"
+    WriteRegExpandStr HKCU "Environment" "Path" "$1"
+    SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=2000
+  done:
+    Pop $2
+    Pop $1
+    Pop $0
+FunctionEnd
+!macroend
+!insertmacro _RemoveFromPathImpl
+
+Function StrContains
+  Exch $1 ; needle
+  Exch
+  Exch $0 ; haystack
+  Exch
+  Push $2
+  Push $3
+  StrCpy $2 -1
+  IntOp $2 $2 + 1
+  StrCpy $3 $0 1 $2
+  StrCmp $3 "" notfound
+  StrCpy $3 $0 ${NSIS_MAX_STRLEN} $2
+  StrCmp $3 $1 found
+  Goto -4
+  found:
+    StrCpy $2 $2 $0 ""
+    StrCpy $0 $2
+    Goto done
+  notfound:
+    StrCpy $0 ""
+  done:
+    Pop $3
+    Pop $2
+    Exch $0
+    Pop $1
+FunctionEnd
+
+Function un.StrContains
+  Exch $1
+  Exch
+  Exch $0
+  Exch
+  Push $2
+  Push $3
+  StrCpy $2 -1
+  IntOp $2 $2 + 1
+  StrCpy $3 $0 1 $2
+  StrCmp $3 "" notfound
+  StrCpy $3 $0 ${NSIS_MAX_STRLEN} $2
+  StrCmp $3 $1 found
+  Goto -4
+  found:
+    StrCpy $2 $2 $0 ""
+    StrCpy $0 $2
+    Goto done
+  notfound:
+    StrCpy $0 ""
+  done:
+    Pop $3
+    Pop $2
+    Exch $0
+    Pop $1
+FunctionEnd
+
+!macro _StrRepImpl
+!macroend
+!insertmacro _StrRepImpl

--- a/scripts/zedg-activate.sh
+++ b/scripts/zedg-activate.sh
@@ -1,0 +1,135 @@
+#!/usr/bin/env bash
+# zedg-activate.sh — 把 ZedG 注册为系统里的 `zed`（生态兼容开关）
+#
+# 适用于 macOS / Linux 手动解压安装的用户。功能：
+#   1. 创建 ~/.local/bin/zed → ZedG 的符号链接（生态工具/git difftool/终端识别）
+#   2. 注册/更新 desktop 入口（应用列表、"默认编辑器"选择器）
+#   3. --revert 一键还原到官方状态
+#
+# 用法:
+#   ./zedg-activate.sh            # 激活生态兼容
+#   ./zedg-activate.sh --revert   # 还原
+#   ./zedg-activate.sh --status   # 查看当前状态
+set -euo pipefail
+
+BIN_DIR="$HOME/.local/bin"
+APP_DIR="$HOME/.local/share/zedg"
+DESKTOP_DIR="$HOME/.local/share/applications"
+ZEDG_CANDIDATES=(
+  "$APP_DIR/ZedG.app/Contents/MacOS/zedg"
+  "$APP_DIR/zedg"
+  "/usr/local/bin/zedg"
+  "/usr/bin/zedg"
+)
+OFFICIAL_CANDIDATES=(
+  "/Applications/Zed.app/Contents/MacOS/zed"
+  "$HOME/.local/bin/zed.orig"
+  "/usr/bin/zed"
+)
+
+find_zedg() {
+  for c in "${ZEDG_CANDIDATES[@]}"; do
+    [ -x "$c" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+
+find_official_zed() {
+  for c in "${OFFICIAL_CANDIDATES[@]}"; do
+    [ -x "$c" ] && { echo "$c"; return 0; }
+  done
+  return 1
+}
+
+do_status() {
+  echo "== ZedG 生态兼容状态 =="
+  if [ -L "$BIN_DIR/zed" ]; then
+    echo "  ~/.local/bin/zed -> $(readlink "$BIN_DIR/zed")  [已激活]"
+  elif [ -x "$BIN_DIR/zed" ]; then
+    echo "  ~/.local/bin/zed 是独立文件（可能是官方安装）       [未接管]"
+  else
+    echo "  ~/.local/bin/zed 不存在                           [未接管]"
+  fi
+  command -v zedg >/dev/null 2>&1 \
+    && echo "  zedg: $(command -v zedg)" \
+    || echo "  zedg: 未安装"
+}
+
+do_activate() {
+  ZEDG_BIN="$(find_zedg)" || {
+    echo "✗ 未找到 ZedG 可执行文件，请先安装 ZedG" >&2
+    exit 1
+  }
+  mkdir -p "$BIN_DIR" "$DESKTOP_DIR"
+
+  # 1. zed 符号链接（备份官方二进制——若它是独立文件而非我们的链接）
+  if [ -e "$BIN_DIR/zed" ] && [ ! -L "$BIN_DIR/zed" ]; then
+    cp "$BIN_DIR/zed" "$BIN_DIR/zed.orig"
+    echo "  已备份官方 zed → zed.orig"
+  fi
+  ln -sf "$ZEDG_BIN" "$BIN_DIR/zed"
+  echo "✓ $BIN_DIR/zed -> $ZEDG_BIN"
+
+  # 2. PATH 提示
+  case ":$PATH:" in
+    *":$BIN_DIR:"*) ;;
+    *) echo "⚠ $BIN_DIR 不在 PATH 中，请将其加入 ~/.zshrc 或 ~/.bashrc" ;;
+  esac
+
+  # 3. desktop 入口（Linux；macOS 用 app bundle 自身的 Info.plist）
+  if [ "$(uname)" = "Linux" ]; then
+    for name in zed zedg; do
+      cat > "$DESKTOP_DIR/$name.desktop" <<DESKTOP
+[Desktop Entry]
+Version=1.0
+Type=Application
+Name=ZedG${name:+ ($name)}
+GenericName=Text Editor
+Comment=Zed 编辑器多语言版
+Exec=$ZEDG_BIN %F
+Icon=$APP_DIR/zedg.png
+Categories=Utility;TextEditor;Development;IDE;
+MimeType=text/plain;text/x-rust;text/x-python;application/json;
+StartupNotify=true
+DESKTOP
+    done
+    command -v update-desktop-database >/dev/null 2>&1 \
+      && update-desktop-database "$DESKTOP_DIR" || true
+    echo "✓ desktop 入口已注册（zed + zedg）"
+  fi
+
+  echo "完成。终端运行 'zed' 或从应用列表启动即为 ZedG。"
+  echo "还原: $0 --revert"
+}
+
+do_revert() {
+  # 还原符号链接
+  if [ -L "$BIN_DIR/zed" ]; then
+    if [ -e "$BIN_DIR/zed.orig" ]; then
+      mv "$BIN_DIR/zed.orig" "$BIN_DIR/zed"
+      echo "✓ 已还原官方 zed（来自 zed.orig）"
+    else
+      rm "$BIN_DIR/zed"
+      echo "✓ 已移除 zed 链接（无官方备份可还原）"
+    fi
+  else
+    echo "  zed 链接不存在，无需还原"
+  fi
+
+  # 移除我们注册的 desktop 入口
+  if [ "$(uname)" = "Linux" ]; then
+    rm -f "$DESKTOP_DIR/zed.desktop" "$DESKTOP_DIR/zedg.desktop"
+    command -v update-desktop-database >/dev/null 2>&1 \
+      && update-desktop-database "$DESKTOP_DIR" || true
+    echo "✓ desktop 入口已移除"
+  fi
+
+  echo "还原完成。"
+}
+
+case "${1:-}" in
+  --revert) do_revert ;;
+  --status) do_status ;;
+  "")       do_activate ;;
+  *) echo "用法: $0 [--revert|--status]"; exit 2 ;;
+esac

--- a/src/zedl10n/translate.py
+++ b/src/zedl10n/translate.py
@@ -269,6 +269,11 @@ async def _translate_async(
         for s in strings:
             if mode == "full" or s not in result.get(file_path, {}):
                 to_translate[s] = ""
+            elif mode == "incremental" and not str(result[file_path].get(s, "")).strip():
+                # 增量模式也要补翻空值：AI 对颜色码、标识符风格的字符串偶尔
+                # 返回空串，而 "s in result" 让空值永远跳过重翻，缺口只会
+                # 越积越多（i18n/zh-CN.json 累积了 4 万+ 空值）。
+                to_translate[s] = ""
         if not to_translate:
             continue
         raw_content = _read_source_file(file_path, source_root)


### PR DESCRIPTION
统一 PR（合并原 #39 的翻译修复）。Close #30, close #34, close #37。

## 1. GLIBC 版本太高（#30）
linux x64 构建机 ubuntu-latest（24.04，glibc 2.39）→ **ubuntu-22.04**（glibc 2.35），产物覆盖 Debian 12 / Mint 21+ / Ubuntu 22.04+。ARM leg 保持 24.04（GitHub 无 22.04 arm runner）。

## 2. libgit2.so.1.8 缺失（#34）
构建时记录链接的 libgit2 → 捆绑到 `/usr/lib/zedg/` → `patchelf --set-rpath '/usr/lib/zedg:$ORIGIN/../lib/zedg'`。tar/deb/rpm 三种包都带。

## 3. 生态不识别 / 默认编辑器（#37）— 两种形态
**Windows：NSIS 安装向导**（`zedg-setup-x86_64/arm64.exe`）
- 向导式释放 + 快捷方式 + 可选 PATH + 完整卸载器
- 组件页可选**覆盖官方 Zed**（默认不勾选）：备份官方 zed.exe → 替换 → 注册表记录，卸载自动还原

**macOS / Linux：用户自触发脚本**（`/usr/bin/zedg-activate.sh` 随包附带）
- `zedg-activate.sh` 激活 / `--revert` 还原 / `--status` 查状态
- 官方 zed 先备份为 zed.orig，还原不丢

## 4. 翻译空值自愈（原 #39）
增量模式跳过条件是"键存在"，导致 AI 返回空串的条目永久留存（42,832 空值，约 6 千条真实 UI 文本）。改为值为空的键同样进入翻译队列，下次流水线自动补齐。

## 范围外（如实说明）
- #31（fcitx5）：zed 上游 Linux IME 问题，需跟进上游
- #33（agent 面板）：仅截图无复现步骤，需报告人补充
