### PR TITLE
fix(translate): 增量模式补翻空值，翻译缺口不再永久留存

### DIFF
--- a/src/zedl10n/translate.py
+++ b/src/zedl10n/translate.py
@@ -269,6 +269,11 @@ async def _translate_async(
         for s in strings:
             if mode == "full" or s not in result.get(file_path, {}):
                 to_translate[s] = ""
+            elif mode == "incremental" and not str(result[file_path].get(s, "")).strip():
+                # 增量模式也要补翻空值：AI 对颜色码、标识符风格的字符串偶尔
+                # 返回空串，而 "s in result" 让空值永远跳过重翻，缺口只会
+                # 越积越多（i18n/zh-CN.json 累积了 4 万+ 空值）。
+                to_translate[s] = ""
         if not to_translate:
             continue
         raw_content = _read_source_file(file_path, source_root)


### PR DESCRIPTION
## 问题

分析 i18n/zh-CN.json（最新版）：**56,439 条中 42,832 条为空值（75%）**。

排除测试/fixture 文件（4,835 条，本就不该翻译）、颜色码、正则、纯标识符后，**约 6,000 条是真实 UI 文本未翻译**，分布在 559 个文件。重灾区：

- agent_ui/acp/thread_view.rs（权限确认、错误提示）
- settings_ui / git_panel / project_search（界面文案）
- editor/folding_ranges、agent/tools/edit_file_tool 等

## 根因

增量模式的跳过条件是 `s not in result`——**键存在但值为空**的条目永远不会重翻。AI 翻译对颜色码、标识符风格字符串偶尔返回空串，这些空值一旦产生就永久留存，每轮新版本还继承上一版的空值。

## 修复

增量模式下，已存在但**值为空**的键同样进入翻译队列。full 模式不变。下次流水线运行即自动补齐全部 6 千条缺口，无需手工干预。

## 验证建议

合并后手动触发一次 01-translate（incremental 模式即可），对比 i18n/zh-CN.json 的空值数：应从 42,832 显著下降。