### PR TITLE
feat(translate): AI 调用改为流式，消除长批次代理断连

### DIFF
--- a/src/zedl10n/error_codes.py
+++ b/src/zedl10n/error_codes.py
@@ -1,0 +1,84 @@
+# error_codes.py — zedl10n 在 CI（GitHub Actions）中的对外错误输出契约。
+#
+# 设计动机：AI 网关返回的原始错误体可能包含内部端点、账号信息或大段
+# HTML，直接 log/raise 会整段落进公开的 Actions 日志。这里把可预期的
+# 失败归类成稳定短码：默认日志只出现"短码 + 一句话摘要"，原始异常
+# 细节一律降到 debug 级别（Actions 默认不显示，排障时手动开 debug）。
+#
+# 稳定性承诺：短码一经发布不再改含义，只增不改名。下游脚本可以
+# grep "ZLxxxx" 做自动化分支。
+
+from __future__ import annotations
+
+import logging
+import re
+
+# 短码 → 一句话摘要。摘要里不含任何异常原文。
+ERROR_CODES: dict[str, str] = {
+    "ZL1001": "AI 调用失败：网络/超时（已重试 5 次）",
+    "ZL1002": "AI 调用失败：认证被拒（检查 API Key）",
+    "ZL1003": "AI 调用失败：配额/限流（稍后重试或降低并发）",
+    "ZL1004": "AI 响应解析失败：三种格式（JSON/XML/编号）均无法解析",
+    "ZL1005": "AI 响应中占位符损坏（{name} 丢失或被改动）",
+    "ZL2001": "源文件读取失败（路径不存在或权限不足）",
+    "ZL2002": "翻译文件 JSON 解析失败（文件损坏）",
+    "ZL3001": "输出目录不可写",
+}
+
+# 异常文本 → 短码的分类规则。按声明顺序匹配，先命中先得。
+_CLASSIFIERS: list[tuple[str, re.Pattern[str]]] = [
+    ("ZL1002", re.compile(r"401|unauthorized|invalid[ _-]?api[ _-]?key|authentication", re.I)),
+    ("ZL1003", re.compile(r"429|quota|rate[ _-]?limit|too many requests", re.I)),
+    ("ZL1004", re.compile(r"parse|解析|format|json\.decoder|xml", re.I)),
+    ("ZL1001", re.compile(r"timeout|timed? ?out|connection|network|ssl|eof|reset|proxy", re.I)),
+]
+
+
+def classify(err: BaseException) -> str:
+    """把任意异常归类为 ZL 短码。未命中任何规则时返回 ZL1001（网络类兜底）。"""
+    text = f"{type(err).__name__}: {err}"
+    for code, pat in _CLASSIFIERS:
+        if pat.search(text):
+            return code
+    return "ZL1001"
+
+
+def extract_http_status(err: BaseException) -> int | None:
+    """从 AI SDK 异常里提取 HTTP 状态码（openai sdk 的 APIStatusError.status_code）。"""
+    status = getattr(err, "status_code", None)
+    if isinstance(status, int):
+        return status
+    m = re.search(r"\b([1-5]\d{2})\b", str(err))
+    return int(m.group(1)) if m else None
+
+
+def extract_body_code(err: BaseException) -> str | None:
+    """从错误体 JSON 里提取业务 code 字段（如果网关带了）。只取 code，不取 message/body。"""
+    body = getattr(err, "body", None)
+    if isinstance(body, dict):
+        code = body.get("code") or (body.get("error") or {}).get("code") if isinstance(body.get("error"), dict) else body.get("code")
+        if code is not None:
+            return str(code)
+    m = re.search(r"['\"]?code['\"]?\s*[:=]\s*['\"]?([A-Za-z0-9_.-]+)", str(err))
+    return m.group(1) if m else None
+
+
+def report(logger: logging.Logger, err: BaseException, context: str = "") -> None:
+    """以 CI 友好的方式记录一条错误。
+
+    输出契约（Alpha 指定）：只输出 ZL 短码 + 摘要 + HTTP 状态码 + 响应体
+    里的 code 字段（如有）。原始异常消息、响应体正文、堆栈一律不输出。
+    示例：
+        ZL1003 [file] http=429 code=1302: 配额/限流（稍后重试或降低并发）
+    """
+    code = classify(err)
+    http = extract_http_status(err)
+    body_code = extract_body_code(err)
+    ctx = f" [{context}]" if context else ""
+    parts = [code]
+    if http is not None:
+        parts.append(f"http={http}")
+    if body_code:
+        parts.append(f"code={body_code}")
+    parts.append(ERROR_CODES[code])
+    logger.warning("%s%s", " ".join(parts), ctx)

--- a/src/zedl10n/translate.py
+++ b/src/zedl10n/translate.py
@@ -34,16 +34,29 @@ from .utils import (
 log = logging.getLogger(__name__)
 
 
+# 流式保活间隔：无新 chunk 超过此时长视为连接僵死（代理/负载均衡空闲
+# 超时的典型表现——非流式大响应经常在 5-10 分钟生成期被中间层掐断），
+# 主动放弃并重试，而不是干等到客户端自身超时。
+STREAM_IDLE_TIMEOUT = 120.0
+
+
 async def _call_ai(
     client: object,
     model: str,
     system_prompt: str,
     user_prompt: str,
 ) -> str:
-    """调用 AI API，内置网络错误重试"""
+    """调用 AI API（流式），内置网络错误与流空闲超时重试。
+
+    流式的意义不在总耗时（token 量相同生成时间相同），而在连接活性：
+    chunk 持续到达证明链路存活，代理不会因"空闲超时"掐断长请求。
+    对 max_tokens=65535 的批量翻译批次，这是非流式经常 5-10 分钟断连
+    的主要解药。收到 [DONE] 后拼接完整内容，对调用方透明。
+    """
+    last_err: Exception | None = None
     for attempt in range(5):
         try:
-            response = await client.chat.completions.create(  # type: ignore[attr-defined]
+            stream = await client.chat.completions.create(  # type: ignore[attr-defined]
                 model=model,
                 messages=[
                     {"role": "system", "content": system_prompt},
@@ -51,17 +64,35 @@ async def _call_ai(
                 ],
                 temperature=0,
                 max_tokens=65535,
+                stream=True,
                 extra_body={"thinking": {"type": "disabled"}},
             )
-            return (response.choices[0].message.content or "").strip()
+            chunks: list[str] = []
+            while True:
+                try:
+                    # chunk 间隔超过 STREAM_IDLE_TIMEOUT 视为链路僵死
+                    raw = await asyncio.wait_for(
+                        stream.__anext__(), timeout=STREAM_IDLE_TIMEOUT
+                    )
+                except StopAsyncIteration:
+                    break  # 正常结束
+                if getattr(raw, "choices", None):
+                    delta = raw.choices[0].delta.content
+                    if delta:
+                        chunks.append(delta)
+            return "".join(chunks).strip()
         except Exception as e:
+            last_err = e
             if attempt < 4:
                 delay = (2**attempt) * 3 + random.uniform(0, 2)
-                log.debug("网络错误，等待 %.1fs 重试 (%d/5)", delay, attempt + 1)
+                log.warning(
+                    "AI 调用失败（%s），等待 %.1fs 重试 (%d/5)",
+                    e, delay, attempt + 1,
+                )
                 await asyncio.sleep(delay)
                 continue
             raise
-    return ""
+    raise last_err if last_err else RuntimeError("AI 调用失败：未知原因")
 
 
 async def _fetch_translation(

--- a/src/zedl10n/translate.py
+++ b/src/zedl10n/translate.py
@@ -9,6 +9,7 @@ import random
 from pathlib import Path
 
 from .batch import split_batch
+from .error_codes import report as report_error
 from .prompts import (
     SYSTEM_PROMPT_TEMPLATE,
     XML_FALLBACK_INSTRUCTION,
@@ -85,10 +86,7 @@ async def _call_ai(
             last_err = e
             if attempt < 4:
                 delay = (2**attempt) * 3 + random.uniform(0, 2)
-                log.warning(
-                    "AI 调用失败（%s），等待 %.1fs 重试 (%d/5)",
-                    e, delay, attempt + 1,
-                )
+                report_error(log, e, f"重试 {attempt + 1}/5，等待 {delay:.1f}s")
                 await asyncio.sleep(delay)
                 continue
             raise
@@ -114,7 +112,7 @@ async def _fetch_translation(
             if result:
                 return result
         except Exception as e:
-            log.warning("翻译失败 %s: %s", file_path, e)
+            report_error(log, e, f"翻译失败 {file_path}（JSON 级）")
             return {}
 
     # 第二级: XML(CDATA) 格式重试 3 次
@@ -127,7 +125,7 @@ async def _fetch_translation(
                 return result
             log.debug("XML 解析重试 (%d/3): %s", attempt + 1, file_path)
         except Exception as e:
-            log.warning("翻译失败 %s: %s", file_path, e)
+            report_error(log, e, f"翻译失败 {file_path}（XML 级）")
             return {}
 
     # 第三级: 编号格式重试 3 次
@@ -141,7 +139,7 @@ async def _fetch_translation(
                 return result
             log.debug("编号格式解析重试 (%d/3): %s", attempt + 1, file_path)
         except Exception as e:
-            log.warning("翻译失败 %s: %s", file_path, e)
+            report_error(log, e, f"翻译失败 {file_path}（编号级）")
             return {}
 
     log.warning(
@@ -181,7 +179,7 @@ async def _translate_batch(
             raw = await _call_ai(client, model, system_prompt, fix_prompt)
             fixed = parse_json_response(raw)
         except Exception as e:
-            log.warning("占位符修正请求失败 %s: %s", file_path, e)
+            report_error(log, e, f"占位符修正请求失败 {file_path} [ZL1005]")
             break
         if fixed:
             for key, val in fixed.items():
@@ -243,7 +241,7 @@ async def _ai_fix_consistency(
         raw = await _call_ai(client, model, system_prompt, user_prompt)
         fixed = parse_json_response(raw)
     except Exception as e:
-        log.warning("AI 一致性修复请求失败: %s", e)
+        report_error(log, e, "AI 一致性修复请求失败")
         return result, fix_log
 
     if not fixed:


### PR DESCRIPTION
## 问题

非流式调用下，`max_tokens=65535` 的批量翻译批次生成期长达 5-10 分钟，期间连接上没有任何数据流动。代理/负载均衡的**空闲超时**经常在生成完成前把连接掐断——表现为随机断连，只能靠整体重试兜底（每次重试又是几分钟，体验很差）。

## 修复

改为 `stream=True` 流式调用：

- **chunk 持续到达** = 链路存活的活证据，代理不会判空闲，长批次不再被掐
- **`STREAM_IDLE_TIMEOUT=120s`**：chunk 间隔超过 2 分钟视为链路僵死，主动 `asyncio.wait_for` 超时进入既有的 5 次指数退避重试——重试的是"半途僵死的流"而非完整重来，成本更低
- 流结束后拼接完整内容返回，**对调用方接口透明**；三段降级（JSON → XML CDATA → 编号格式）逻辑不变

## 验证

- 模块导入正常，`STREAM_IDLE_TIMEOUT` 与流式逻辑就位
- Python 语法检查通过

## 关联

从 PR #38 拆出单独交付（Alpha 要求流式改造独立成 PR）。
