### PR TITLE
feat(scoop): 新增 zedg-compat manifest（可选覆盖官方 zed 命令）

### DIFF
--- a/.github/workflows/03-update-scoop.yml
+++ b/.github/workflows/03-update-scoop.yml
@@ -25,6 +25,11 @@ on:
           - stable     # 仅更新稳定版
           - prerelease # 仅更新预览版
           - both       # 同时拉取最新稳定版和预览版并推送
+      compat:
+        description: "是否生成 zedg-compat manifest（额外 shim `zed` 命令，覆盖官方 zed 的 PATH 位置）"
+        required: false
+        default: "false"
+        type: boolean
 
 permissions:
   contents: read
@@ -43,6 +48,7 @@ jobs:
           INPUT_TAG: ${{ inputs.version_tag }}
           INPUT_MODE: ${{ inputs.mode }}
           INPUT_IS_PRE: ${{ inputs.is_prerelease }}
+          INPUT_COMPAT: ${{ inputs.compat }}
           EVENT_TAG: ${{ github.event.release.tag_name }}
           EVENT_IS_PRE: ${{ github.event.release.prerelease }}
           SCOOP_PAT: ${{ secrets.TAP_GITHUB_TOKEN }}
@@ -73,7 +79,7 @@ jobs:
 
           # ── 生成单个 manifest ──────────────────────────────────────
           make_manifest() {
-            local tag="$1" is_pre="$2" out="$3"
+            local tag="$1" is_pre="$2" out="$3" compat="${4:-false}"
             local clean="${tag#v}"
             local repo_url="https://github.com/${GH_REPO}"
             local desc="Zed Editor (Localized / 汉化版)"
@@ -89,6 +95,7 @@ jobs:
 
             local manifest
             manifest=$(jq -n \
+              --argjson compat "$compat" \
               --arg version  "$clean" \
               --arg desc     "$desc" \
               --arg homepage "$repo_url" \
@@ -101,7 +108,8 @@ jobs:
                 version: $version, description: $desc,
                 homepage: $homepage, license: "GPL-3.0-only",
                 architecture: {"64bit": {url: $url_x64, hash: $hash_x64}},
-                bin: [["bin\\ZedG.exe", "zedg"]],
+                bin: ([["bin\\ZedG.exe", "zedg"]] +
+                      (if $compat == "true" then [["bin\\ZedG.exe", "zed"]] else [] end)),
                 shortcuts: [["ZedG.exe", "ZedG"]],
                 post_install: [
                   "$desktop = [Environment]::GetFolderPath(\"Desktop\")",
@@ -143,6 +151,9 @@ jobs:
 
           # ── 判断模式与目标版本 ─────────────────────────────────────
           MODE="${INPUT_MODE:-auto}"
+          # compat=true 时额外生成 zedg-compat(.preview).json：除 zedg 命令外
+          # 同时 shim `zed`，让生态工具/git difftool 把 ZedG 当默认编辑器。
+          COMPAT="${INPUT_COMPAT:-false}"
           TARGET_TAG=""
           IS_PRE="false"
 
@@ -161,6 +172,10 @@ jobs:
             echo "both 模式：stable=$STABLE_TAG  prerelease=${PRE_TAG:-（无）}"
             make_manifest "$STABLE_TAG" "false" /tmp/manifests/zedg.json
             [ -n "$PRE_TAG" ] && make_manifest "$PRE_TAG" "true" /tmp/manifests/zedg-preview.json
+            if [ "$COMPAT" = "true" ]; then
+              make_manifest "$STABLE_TAG" "false" /tmp/manifests/zedg-compat.json "true"
+              [ -n "$PRE_TAG" ] && make_manifest "$PRE_TAG" "true" /tmp/manifests/zedg-compat-preview.json "true"
+            fi
           else
             if [ -z "$TARGET_TAG" ] && [ -n "$INPUT_TAG" ]; then
               TARGET_TAG="$INPUT_TAG"
@@ -181,6 +196,13 @@ jobs:
               make_manifest "$TARGET_TAG" "true"  /tmp/manifests/zedg-preview.json
             else
               make_manifest "$TARGET_TAG" "false" /tmp/manifests/zedg.json
+            fi
+            if [ "$COMPAT" = "true" ]; then
+              if [ "$IS_PRE" = "true" ]; then
+                make_manifest "$TARGET_TAG" "true"  /tmp/manifests/zedg-compat-preview.json "true"
+              else
+                make_manifest "$TARGET_TAG" "false" /tmp/manifests/zedg-compat.json "true"
+              fi
             fi
           fi
 

--- a/README.md
+++ b/README.md
@@ -91,6 +91,20 @@ scoop bucket add zedg https://github.com/x6nux/scoop-zedg
 scoop install zedg-preview
 ```
 
+**生态兼容版（覆盖官方 zed 命令）：**
+
+```powershell
+scoop bucket add zedg https://github.com/x6nux/scoop-zedg
+scoop install zedg-compat
+```
+
+> **`zedg` 与 `zedg-compat` 的区别：** 两者安装同一 ZedG 编辑器，区别在命令行 shim：
+> - `zedg` — 只注册 `zedg` 命令，不影响官方 Zed（推荐已单独安装官方 Zed 的用户）
+> - `zedg-compat` — 额外注册 `zed` 命令，生态工具（git difftool、终端 `zed .` 等）会自动识别 ZedG 为默认编辑器。
+>   若之前安装过官方 Zed，建议先卸载或重命名其 `zed.exe`，避免命令冲突。
+>
+> 两者可随时切换：`scoop uninstall zedg && scoop install zedg-compat`（反之亦然）。
+
 > **自动更新（可选）：** 通过 Windows 计划任务每天定时更新（需要管理员权限）。
 > ```powershell
 > # 启用（每天中午 12:00 自动更新 ZedG）
@@ -109,6 +123,7 @@ scoop install zedg-preview
 - JSON <-> Excel 双向转换，支持人工校对
 - 跨平台构建（Windows / Linux / macOS），含应用图标
 - GitHub Actions 全自动流水线：扫描 -> 翻译 -> 构建 -> 发布
+- **可选覆盖官方 Zed**：Windows 安装向导（NSIS 组件页勾选）/ Scoop（`zedg-compat` 包）/ macOS & Linux（`zedg-activate.sh` 一键激活，`--revert` 还原）
 
 ## 自动化流水线
 
@@ -166,6 +181,35 @@ zedl10n replace --input i18n/zh-CN.json --source-root zed
 python3 patch_agent_env.py --source-root zed
 cd zed && cargo build --release
 ```
+
+### 生态兼容：让系统把 ZedG 当作 `zed`（可选）
+
+生态工具（git difftool、终端 `zed .`、"默认编辑器"选择器）通常找名为 `zed` 的命令。
+ZedG 提供三种方式注册，均**不破坏官方 Zed 安装**（可随时还原）：
+
+**Windows（NSIS 安装包）**
+
+安装向导的组件页勾选 **"覆盖官方 Zed 安装"**：
+- 自动备份官方 `zed.exe` → `zed.exe.official.bak` 后替换
+- 卸载 ZedG 时自动还原官方版本
+
+**Windows（Scoop）**
+
+安装 `zedg-compat` 包（额外 shim `zed` 命令）：
+
+```powershell
+scoop install zedg-compat
+```
+
+**macOS / Linux（tar.gz / deb / rpm 手动安装）**
+
+```bash
+zedg-activate.sh            # 激活：创建 ~/.local/bin/zed 链接 + 注册 desktop 入口
+zedg-activate.sh --status   # 查看当前接管状态
+zedg-activate.sh --revert   # 一键还原官方状态（官方 zed 已自动备份为 zed.orig）
+```
+
+> Linux deb/rpm 包还会自动注册 `zedg.desktop` 并关联 `text/plain`，应用列表直接可见。
 
 > **`patch_agent_env.py` 补丁说明：** Zed 源码中 `agent_server_store.rs` 会强制将 `ANTHROPIC_API_KEY` 设为空字符串，导致用户系统中已配置的 API Key 被清除；同时 `claude.rs` 的 `connect()` 方法没有像 Codex/Gemini 那样从系统环境变量读取并透传 API Key。该补丁自动修复这两个问题：
 > - **补丁 1**：删除 `agent_server_store.rs` 中 `env.insert("ANTHROPIC_API_KEY", "")` 的强制清空行


### PR DESCRIPTION
## 盲区修复

Scoop 安装的 ZedG 之前只 shim `zedg` 命令，无法像 NSIS 安装器那样选择覆盖官方 zed —— 生态工具（git difftool、终端 `zed` 命令等）不识别。

## 方案

Scoop 不支持安装时交互选择，改用**多 manifest** 让用户装包时选择：

- `scoop install zedg` —— 安全版（现状）：只 shim `zedg`，不动官方 zed
- `scoop install zedg-compat` —— **生态兼容版**：同时 shim `zed`，接管官方 zed 的命令位

## 实现

- `03-update-scoop.yml` 新增 `compat` 输入（workflow_dispatch，默认 false）
- 开启后 make_manifest 额外生成 `zedg-compat.json`（及其 preview 版），bin 数组多一项 `["bin\\ZedG.exe", "zed"]`
- 推送循环 `cp /tmp/manifests/*.json` 自动包含新 manifest，无需改推送逻辑

## 使用

```powershell
scoop bucket add zedg https://github.com/x6nux/scoop-zedg
scoop install zedg           # 原方式
scoop install zedg-compat    # 生态兼容（接管 zed 命令）
```

手动触发：Actions → 03 更新 Scoop Manifest → 勾选 compat → 运行