### PR TITLE
fix(ci): linux x64 clang 编译器 + arm64 libgit2 发现步骤

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -1030,6 +1030,11 @@ jobs:
             libssl-dev libudev-dev libclang-dev clang cmake mold rpm \
             patchelf libgit2-dev
           echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
+          # issue #30: 22.04 的 gcc-11 对 webrtc-sys 的 C++ 头文件报
+          # "changes meaning of 'Network'"（clang 只警告，gcc 当错误）。
+          # 显式指定 clang++ 作为 C++ 编译器，与 24.04 默认行为对齐。
+          echo "CXX=clang++" >> $GITHUB_ENV
+          echo "CC=clang" >> $GITHUB_ENV
 
       - name: 克隆 Zed 源码并检出 Tag
         run: |

--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -1982,6 +1982,15 @@ jobs:
           git checkout $BUILD_VERSION
           echo "Checked out $BUILD_VERSION"
 
+      - name: 记录 libgit2 动态库位置（打包捆绑用，issue #34）
+        run: |
+          LIBGIT2=$(ldconfig -p | grep 'libgit2\.so' | head -1 | awk '{print $NF}')
+          if [ -z "$LIBGIT2" ]; then
+            echo "::error::libgit2.so not found via ldconfig"
+            exit 1
+          fi
+          echo "LIBGIT2_SO=$LIBGIT2" >> "$GITHUB_ENV"
+          echo "libgit2 runtime lib: $LIBGIT2"
       - name: 下载本地化补丁
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## 两个 CI 修复（上一轮 run 33689039801 的失败）

### 1. build-linux-x86_64：webrtc-sys 编译失败
ubuntu-22.04（GLIBC 2.35 修复用，issue #30）上 cc-rs 回落到 g++ 编译 webrtc-sys 的 C++，gcc-11 把 `changes meaning of 'Network'` 当错误。显式 `CXX=clang++ / CC=clang`，与 24.04 行为对齐。

### 2. build-linux-aarch64：打包 `cp: cannot stat ''`
arm64 leg 缺少 x64 leg 的『记录 libgit2 动态库位置』步骤（issue #34 捆绑），`LIBGIT2_SO` 为空。补齐同款步骤。

> 注：这两个 commit 曾误推到已合并的 #38 分支，本 PR 基于最新 main 重新 cherry-pick。