### PR TITLE
fix(nsis): Windows 安装包编译失败——StrRep 宏实现 + 版本占位符替换

### DIFF
--- a/packaging/windows/zedg-setup.nsi
+++ b/packaging/windows/zedg-setup.nsi
@@ -137,7 +137,7 @@ FunctionEnd
 ; ---------------------------------------------------------------------------
 Function .onInstSuccess
   ; 记录版本信息
-  WriteRegStr HKCU "Software\${APP_NAME}" "Version" "${VERSION_PLACEHOLDER}"
+  WriteRegStr HKCU "Software\${APP_NAME}" "Version" "VERSION_PLACEHOLDER"
 FunctionEnd
 
 ; ---------------------------------------------------------------------------
@@ -201,6 +201,101 @@ Function AddToPath
 FunctionEnd
 !macroend
 !insertmacro _AddToPathImpl
+
+!macro _StrRepImpl
+  !ifndef _STRREP_DEFINED
+    !define _STRREP_DEFINED
+    !macro StrRep output string search replace
+      Push `${string}`
+      Push `${search}`
+      Push `${replace}`
+      !ifndef __UNINSTALL__
+        Call StrRep
+      !else
+        Call un.StrRep
+      !endif
+      Pop ${output}
+    !macroend
+    Function StrRep
+      Exch $R2 ; replace
+      Exch $R1 ; search
+      Exch 2
+      Exch $R0 ; string
+      Push $R3
+      Push $R4
+      Push $R5
+      Push $R6
+      StrCpy $R3 0
+      StrLen $R4 $R1
+      loop:
+        StrCpy $R5 $R0 $R4 $R3
+        StrCmp $R5 $R1 found
+        StrCmp $R5 "" done
+        IntOp $R3 $R3 + 1
+        Goto loop
+      found:
+        StrCpy $R6 $R0 $R3
+        IntOp $R3 $R3 + $R4
+        StrCpy $R0 $R0 "" $R3
+        StrCpy $R0 $R6$R2$R0
+        StrCpy $R3 0
+        StrLen $R4 $R1
+        StrCmp $R4 0 done
+        Goto loop
+      done:
+        Pop $R6
+        Pop $R5
+        Pop $R4
+        Pop $R3
+        Push $R0
+        Pop $R0
+        Exch 2
+        Pop $R2
+        Pop $R1
+        Pop $R0
+        Push $R0
+      FunctionEnd
+      Function un.StrRep
+        Exch $R2
+        Exch $R1
+        Exch 2
+        Exch $R0
+        Push $R3
+        Push $R4
+        Push $R5
+        Push $R6
+        StrCpy $R3 0
+        StrLen $R4 $R1
+        loop_u:
+          StrCpy $R5 $R0 $R4 $R3
+          StrCmp $R5 $R1 found_u
+          StrCmp $R5 "" done_u
+          IntOp $R3 $R3 + 1
+          Goto loop_u
+        found_u:
+          StrCpy $R6 $R0 $R3
+          IntOp $R3 $R3 + $R4
+          StrCpy $R0 $R0 "" $R3
+          StrCpy $R0 $R6$R2$R0
+          StrCpy $R3 0
+          StrLen $R4 $R1
+          StrCmp $R4 0 done_u
+          Goto loop_u
+        done_u:
+          Pop $R6
+          Pop $R5
+          Pop $R4
+          Pop $R3
+          Push $R0
+          Pop $R0
+          Exch 2
+          Pop $R2
+          Pop $R1
+          Pop $R0
+          Push $R0
+        FunctionEnd
+  !endif
+!insertmacro _StrRepImpl
 
 !macro _RemoveFromPathImpl
 Function un.RemoveFromPath
@@ -278,6 +373,4 @@ Function un.StrContains
     Pop $1
 FunctionEnd
 
-!macro _StrRepImpl
-!macroend
-!insertmacro _StrRepImpl
+


### PR DESCRIPTION
## 背景

run 33689039801 的 build-windows-aarch64 在 NSIS 打包步失败（x64 leg 尚未跑到打包，也会踩中同一 bug）：

1. **Invalid command: `${StrRep}`** —— zedg-setup.nsi 里 `` 只有一个**空宏体**且 `!insertmacro _StrRepImpl` 排在 `_RemoveFromPathImpl`（用点）之后。卸载时从 PATH 移除 ZedG 的逻辑直接编译不过。
2. **`{v1.19.0-pre}` unknown variable** —— nsi 里写成 `${VERSION_PLACEHOLDER}`，workflow 的 `-replace 'VERSION_PLACEHOLDER'` 纯文本替换后残留 `${v1.19.0-pre}`，NSIS 解析为变量。

## 修复

- 完整实现 `StrRep` 宏（NSIS Wiki 标准实现，含安装/卸载双函数），并把定义块移到所有使用点之前
- 版本写入处去掉 `${}`，替换后变成干净的 `v1.19.0-pre` 字符串

## 附带说明

- `libgit2.dll no files found (warning 7010)` 是 `File /nonfatal` 的预期警告：Windows 构建链不产出 libgit2.dll（git2-rs 静态链接），无需处理