### PR TITLE
fix(ci): arm64 补齐 libgit2-dev 安装，修复 ldconfig 找不到 libgit2.so

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -2012,7 +2012,8 @@ jobs:
             libxcb-shape0-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-randr0-dev libxcb-keysyms1-dev libxcb-util-dev \
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
-            libssl-dev libudev-dev libclang-dev clang cmake mold rpm
+            libssl-dev libudev-dev libclang-dev clang cmake mold rpm \
+            patchelf libgit2-dev
           echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
 
       - name: 克隆 Zed 源码并检出 Tag


### PR DESCRIPTION
## 根因

新 run 33699915458 中 build-linux-aarch64 失败于 `记录 libgit2 动态库位置`：

```
##[error]libgit2.so not found via ldconfig
```

PR #42 给 arm64 job 加了 libgit2 记录/打包步骤，但漏改了 arm64 的
`安装依赖` apt 列表（没装 libgit2-dev）。ubuntu-24.04-arm 镜像不预装
libgit2，记录步骤直接报错退出。x64 job 的 apt 列表里已有 `patchelf libgit2-dev`。

## 修复

arm64 `安装依赖` 的 apt install 末尾补上 `patchelf libgit2-dev`，与 x64 一致。