### PR TITLE
fix(ci): 安装依赖后显式 ldconfig，避免 libgit2.so 不进 ld 缓存

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -1069,6 +1069,7 @@ jobs:
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
             libssl-dev libudev-dev libclang-dev clang cmake mold rpm \
             patchelf libgit2-dev
+          sudo ldconfig
           echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
           # issue #30: 22.04 的 gcc-11 对 webrtc-sys 的 C++ 头文件报
           # "changes meaning of 'Network'"（clang 只警告，gcc 当错误）。
@@ -2014,6 +2015,7 @@ jobs:
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
             libssl-dev libudev-dev libclang-dev clang cmake mold rpm \
             patchelf libgit2-dev
+          sudo ldconfig
           echo "RUSTFLAGS=-C linker=clang -C link-arg=-fuse-ld=mold" >> $GITHUB_ENV
 
       - name: 克隆 Zed 源码并检出 Tag


### PR DESCRIPTION
## 根因
run 33699915458 的 build-linux-aarch64 job 失败：`ldconfig -p` 查不到 `libgit2.so`。

PR #46 (1c9e953) 已给 arm64 job 补装 `libgit2-dev`，但**当前 in-progress run 用的是修复前的 commit (78efa8a)**，所以本次失败是预期的旧代码结果。

## 本 PR 的额外加固
apt 装包后 ld 缓存刷新在 arm64 runner 上出现过未生效的案例（本次日志即证据——安装步骤成功但 ldconfig 查不到）。给两个 linux build job 的安装步骤统一追加 `sudo ldconfig`，确保 `ldconfig -p` 检测稳定通过。

## 关联
- 前置：#42、#46
- 监控 job：48f75b95d361 (zedg-build-watch-fix-loop)