### PR TITLE
fix(ci): x64 Linux 打包前补齐 dist 目录 mkdir

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -1297,6 +1297,12 @@ jobs:
           objcopy --strip-debug zed/target/release/zed
           objcopy --strip-debug zed/target/release/cli
 
+          mkdir -p dist/usr/bin
+          mkdir -p dist/usr/libexec
+          mkdir -p dist/usr/share/applications
+          mkdir -p dist/usr/share/icons/hicolor/512x512/apps
+          mkdir -p dist/usr/share/icons/hicolor/1024x1024/apps
+
           # issue #34: bundle the libgit2 the binary was linked against —
           # user machines without libgit2.so.1.8 cannot start zedg at all.
           LIBGIT2_DIR=$(dirname "${LIBGIT2_SO}")


### PR DESCRIPTION
## 根因
run 33705517040 build-linux-x86_64 失败：
`cp: cannot create regular file 'dist/usr/share/icons/hicolor/512x512/apps/zedg.png': No such file or directory`

x64 打包步骤 cp 图标/写 desktop 文件到 dist/usr/share/... ，但只 mkdir 过 dist/usr/lib/zedg。arm64 打包段有完整 mkdir 列表所以没事；x64 此前能通过是旧 run 的 artifact 目录残留，不可复现依赖。

## 修复
x64 打包段开头对齐 arm64 的 mkdir 集合（usr/bin、usr/libexec、usr/share/applications、icons 512/1024）。

## 关联
- 失败 job: 100496974744 (run 33705517040)
- 其余平台不受影响：linux-aarch64 / macos-aarch64 已 success