### PR TITLE
fix(nsis): StrRep 宏改为顶层定义，修复宏嵌套定义错误

### DIFF
--- a/packaging/windows/zedg-setup.nsi
+++ b/packaging/windows/zedg-setup.nsi
@@ -202,10 +202,7 @@ FunctionEnd
 !macroend
 !insertmacro _AddToPathImpl
 
-!macro _StrRepImpl
-  !ifndef _STRREP_DEFINED
-    !define _STRREP_DEFINED
-    !macro StrRep output string search replace
+!macro StrRep output string search replace
       Push `${string}`
       Push `${search}`
       Push `${replace}`
@@ -294,8 +291,6 @@ FunctionEnd
           Pop $R0
           Push $R0
         FunctionEnd
-  !endif
-!insertmacro _StrRepImpl
 
 !macro _RemoveFromPathImpl
 Function un.RemoveFromPath


### PR DESCRIPTION
## 问题
build-windows-aarch64 job 中 makensis 报错：
```
Error: can't define a macro inside a macro!
Error in script "zedg-setup.nsi" on line 207 -- aborting creation process
```

## 根因
`zedg-setup.nsi` 中 `StrRep` 宏被包在 `_StrRepImpl` 宏内部定义（`!macro` 嵌套 `!macro`），NSIS 不允许。且 `_StrRepImpl` 宏本身缺少 `!macroend` 收尾（原文件里 `!endif` 后直接 `!insertmacro _StrRepImpl`，没有 `!macroend`），整个结构无法编译。

## 修复
- 去掉 `_StrRepImpl` 包裹层，`StrRep` 宏改为顶层一次性定义（脚本仅编译一次，无需 ifndef 防重）。
- 删除多余的 `!endif` 与失效的 `!insertmacro _StrRepImpl`。

## 验证
- 修复 Linux x64 图标 cp 失败的 PR #48 已合并进 main（本分支基于其上）。
- 本 PR 只影响 Windows NSIS 打包步骤。