### PR TITLE
fix(ci): x64 打包段补齐 dist/ 二进制，修复 rpm 打包 cp 失败

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -1340,6 +1340,17 @@ jobs:
           MimeType=text/plain;
           DESKTOP
 
+          # issue #37 compat: ecosystem tools exec `zed`, not `zedg`
+          # issue #52: #34/#37 rewrite dropped the binary cp into dist/ —
+          # rpm spec reads dist/usr/bin/zedg so it must exist (align arm64).
+          cp "zed/target/release/zed" dist/usr/bin/zedg
+          cp "zed/target/release/cli" dist/usr/libexec/zedg
+          ln -sf zedg dist/usr/bin/zed
+          ln -sf zedg dist/usr/libexec/zed-cli
+          # 生态兼容开关脚本（用户自行运行）
+          cp scripts/zedg-activate.sh dist/usr/bin/zedg-activate
+          chmod 755 dist/usr/bin/zedg-activate
+
           tar -czvf "zedg-${LANG_LOWER}-linux-x86_64-${BUILD_VERSION}.tar.gz" -C dist .
 
           # === deb 包 ===


### PR DESCRIPTION
## 根因
run 33720190186 build-linux-x86_64 失败：rpm spec `%install` 从 `${_zedg_dist}/usr/bin/zedg` 拷贝，但 #34/#37 打包重写后 x64 段只把二进制拷进 `deb-pkg/`，从未写入 `dist/usr/bin/zedg` / `dist/usr/libexec/zedg`：

```
cp: cannot stat '.../dist/usr/bin/zedg': No such file or directory
error: Bad exit status from /var/tmp/rpm-tmp (%install)
```

deb 打包自己直接从 target/ 拷贝所以成功了，失败点只在 rpm。

## 修复
对齐 aarch64 段（该段完整无缺、一直成功）：
- 补 `cp zed → dist/usr/bin/zedg`、`cp cli → dist/usr/libexec/zedg`
- 补 issue #37 兼容 symlink（`zed`、`zed-cli`）
- 补 `zedg-activate.sh` 拷贝进 dist（tar.gz 包同样之前缺二进制）

## 验证
合并后由下一轮 02-build run 验证。