### PR TITLE
fix(ci): NSIS StrRep macro invoked wrong way breaks windows installer build

### DIFF
--- a/packaging/windows/zedg-setup.nsi
+++ b/packaging/windows/zedg-setup.nsi
@@ -303,7 +303,7 @@ Function un.RemoveFromPath
   Call un.StrContains
   Pop $2
   StrCmp $2 "" done
-    ${StrRep} $1 "$1;" ";$0;" ";"
+    !insertmacro StrRep $1 "$1;" ";$0;" ";"
     WriteRegExpandStr HKCU "Environment" "Path" "$1"
     SendMessage ${HWND_BROADCAST} ${WM_WININICHANGE} 0 "STR:Environment" /TIMEOUT=2000
   done:


### PR DESCRIPTION
Root cause (run 33720190186, build-windows-aarch64): NSIS fails with Invalid command StrRep-in-braces at _RemoveFromPathImpl macroline 11. The dollar-brace StrRep form is StrFunc.nsh define-substitution syntax; a hand-written exclamation-macro named StrRep can only be called via insertmacro and never defines the dollar-brace form. The single call site in un.RemoveFromPath thus failed to compile, setup.exe was never produced, and Move-Item failed downstream. Fix: replace the single call with the insertmacro form (one-line change). Note: zed-dist libgit2.dll no-files-found is only NSIS warning 7010, non-fatal, left as is.