### PR TITLE
docs: 移除 Star History 图表

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,10 +6,6 @@
 
 [Zed 编辑器](https://github.com/zed-industries/zed) 汉化版（中文版），支持简体中文、繁体中文、日语、韩语等多语言。AI 驱动的全自动翻译与构建流水线，开箱即用。
 
-## Star History
-
-[![Star History Chart](https://api.star-history.com/svg?repos=x6nux/zed-globalization&type=Date)](https://star-history.com/#x6nux/zed-globalization&Date)
-
 > **Zed 汉化版** | Zed 中文版 | Zed Chinese | Zed Localized | Zed 多语言 | Zed 国际化 | Zed i18n | Zed l10n
 
 ## 下载安装


### PR DESCRIPTION
GitHub 调整 star 数据 API 权限后，非仓库所有者看到的 Star History 图表不再更新，展示无意义，按 Alpha 指示移除。