### PR TITLE
fix(nsis): 安装脚本加 UTF-8 BOM，修复组件名乱码

### DIFF
--- a/packaging/windows/zedg-setup.nsi
+++ b/packaging/windows/zedg-setup.nsi
@@ -1,4 +1,4 @@
-# ZedG Windows 安装程序（NSIS）
+﻿# ZedG Windows 安装程序（NSIS）
 # 生成: zedg-setup-x64.exe / zedg-setup-arm64.exe
 # 功能:
 #   1. 释放 ZedG.exe + bin\ZedG.exe(cli) + 运行时库到安装目录


### PR DESCRIPTION
## 现象
用户安装 ZedG 时组件选择页三个组件名全部乱码（mojibake），仅 ZedG 字样可辨。

## 根因
`zedg-setup.nsi` 为无 BOM 的 UTF-8 编码。CI 在 Windows runner 上调 makensis 时，脚本按系统 ANSI 代码页（简体中文系统 = GBK/cp936）解析，UTF-8 中文被按 GBK 解释 → 乱码。macOS 本地测试时 ACP 恰好是 UTF-8，故未暴露。

日志证据（此前 NSIS 构建日志）：`Processing script file: zedg-setup.nsi (ACP)`

## 修复
文件头添加 UTF-8 BOM（EF BB BF）。NSIS 3.x 检测到 BOM 后强制按 UTF-8 解析，不再依赖系统代码页。

本地 makensis 3.12 编译验证通过。