### PR TITLE
fix(nsis): Unicode true 修复乱码；重写 StrContains 修复安装卡死；CI 保留 BOM

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -580,7 +580,7 @@ jobs:
         shell: pwsh
         run: |
           Copy-Item packaging\windows\zedg-setup.nsi .
-          (Get-Content zedg-setup.nsi) -replace 'VERSION_PLACEHOLDER', $env:BUILD_VERSION | Set-Content zedg-setup.nsi
+          (Get-Content zedg-setup.nsi -Raw) -replace 'VERSION_PLACEHOLDER', $env:BUILD_VERSION | Set-Content zedg-setup.nsi -Encoding utf8BOM
           & "C:\Program Files (x86)\NSIS\makensis.exe" zedg-setup.nsi
           Move-Item ..\zedg-setup.exe "zedg-setup-windows-x86_64-$env:BUILD_VERSION.exe"
 
@@ -929,7 +929,7 @@ jobs:
         shell: pwsh
         run: |
           Copy-Item packaging\windows\zedg-setup.nsi .
-          (Get-Content zedg-setup.nsi) -replace 'VERSION_PLACEHOLDER', $env:BUILD_VERSION | Set-Content zedg-setup.nsi
+          (Get-Content zedg-setup.nsi -Raw) -replace 'VERSION_PLACEHOLDER', $env:BUILD_VERSION | Set-Content zedg-setup.nsi -Encoding utf8BOM
           & "C:\Program Files (x86)\NSIS\makensis.exe" zedg-setup.nsi
           Move-Item ..\zedg-setup.exe "zedg-setup-windows-aarch64-$env:BUILD_VERSION.exe"
 

--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ target/
 
 # macOS
 .DS_Store
+
+# 本地 NSIS 安装器测试产物
+test-nsis/

--- a/packaging/windows/zedg-setup.nsi
+++ b/packaging/windows/zedg-setup.nsi
@@ -16,6 +16,10 @@
 !include "MUI2.nsh"
 !include "FileFunc.nsh"
 
+; Unicode 安装程序: 字符串以 UTF-16 存储, 不随编译机/用户系统代码页变化。
+; 否则 ANSI 模式下中文在英文 CI 编译机 (CP1252) 上被转成 '?'，装出来就是乱码
+Unicode true
+
 Name "${APP_NAME}"
 OutFile "..\zedg-setup.exe"
 InstallDir "$LOCALAPPDATA\Programs\ZedG"
@@ -314,58 +318,65 @@ FunctionEnd
 !macroend
 !insertmacro _RemoveFromPathImpl
 
+; StrContains: 在 haystack 中查找 needle, 命中返回从命中处起的尾部, 未命中返回空串。
+; 调用约定: 先 push haystack 再 push needle (needle 在栈顶), 返回值压栈
+; 注意: 全部使用标签跳转, 禁用相对 Goto (相对偏移跳错会跳过自增导致死循环)
 Function StrContains
-  Exch $1 ; needle
-  Exch
-  Exch $0 ; haystack
-  Exch
-  Push $2
-  Push $3
-  StrCpy $2 -1
-  IntOp $2 $2 + 1
-  StrCpy $3 $0 1 $2
-  StrCmp $3 "" notfound
-  StrCpy $3 $0 ${NSIS_MAX_STRLEN} $2
-  StrCmp $3 $1 found
-  Goto -4
-  found:
-    StrCpy $2 $2 $0 ""
-    StrCpy $0 $2
-    Goto done
-  notfound:
-    StrCpy $0 ""
-  done:
-    Pop $3
-    Pop $2
-    Exch $0
-    Pop $1
+  Exch $R0            ; $R0 = needle, 栈: [haystack, $R0_old]
+  Exch                ; 栈: [$R0_old, haystack]
+  Exch $R1            ; $R1 = haystack, 栈: [$R0_old, $R1_old]
+  Push $R2
+  Push $R3
+  Push $R4
+  StrLen $R2 $R0      ; needle 长度
+  StrCpy $R3 0        ; 扫描位置
+  loop_scan:
+    StrCpy $R4 $R1 $R2 $R3
+    StrCmp $R4 $R0 scan_found
+    StrCmp $R4 "" scan_notfound
+    IntOp $R3 $R3 + 1
+    Goto loop_scan
+  scan_found:
+    StrCpy $R1 $R1 "" $R3
+    Goto scan_done
+  scan_notfound:
+    StrCpy $R1 ""
+  scan_done:
+    Pop $R4
+    Pop $R3
+    Pop $R2
+    Exch              ; 栈: [$R1_old, $R0_old]
+    Pop $R0
+    Exch $R1          ; 栈顶 = 结果, $R1 恢复
 FunctionEnd
 
 Function un.StrContains
-  Exch $1
+  Exch $R0
   Exch
-  Exch $0
-  Exch
-  Push $2
-  Push $3
-  StrCpy $2 -1
-  IntOp $2 $2 + 1
-  StrCpy $3 $0 1 $2
-  StrCmp $3 "" notfound
-  StrCpy $3 $0 ${NSIS_MAX_STRLEN} $2
-  StrCmp $3 $1 found
-  Goto -4
-  found:
-    StrCpy $2 $2 $0 ""
-    StrCpy $0 $2
-    Goto done
-  notfound:
-    StrCpy $0 ""
-  done:
-    Pop $3
-    Pop $2
-    Exch $0
-    Pop $1
+  Exch $R1
+  Push $R2
+  Push $R3
+  Push $R4
+  StrLen $R2 $R0
+  StrCpy $R3 0
+  loop_scan_u:
+    StrCpy $R4 $R1 $R2 $R3
+    StrCmp $R4 $R0 scan_found_u
+    StrCmp $R4 "" scan_notfound_u
+    IntOp $R3 $R3 + 1
+    Goto loop_scan_u
+  scan_found_u:
+    StrCpy $R1 $R1 "" $R3
+    Goto scan_done_u
+  scan_notfound_u:
+    StrCpy $R1 ""
+  scan_done_u:
+    Pop $R4
+    Pop $R3
+    Pop $R2
+    Exch
+    Pop $R0
+    Exch $R1
 FunctionEnd
 
 


### PR DESCRIPTION
## 问题与修复

### 1. 安装器中文乱码（组件名/注册表）
- **根因**：`zedg-setup.nsi` 缺 `Unicode true`。NSIS 3 默认编 **ANSI** 安装包，所有字符串按**编译机**代码页转换——CI 英文机 (CP1252) 上中文全部变 `?` 烧进安装包。#56 加的 UTF-8 BOM 只解决了 makensis「读取」，没解决「输出」编码。
- **修复**：加 `Unicode true`，字符串以 UTF-16 存储，任意语言系统显示一致。

### 2. 安装卡死在 94%（CPU 烧满、窗口假死）
- **根因**：`StrContains` / `un.StrContains` 里 `Goto -4` 相对跳转落点少一行，跳过了 `IntOp $2 $2 + 1` 自增，扫描位置永远停在 0 死循环。安装时 PATH 段（默认勾选）`AddToPath` 触发；卸载时 `un.RemoveFromPath` 同样触发。
- **本地复现**：桩安装器卡在 94%「创建快捷方式」，进程 CPU 55 秒+持续上涨（非挂起等待，是忙循环）。
- **修复**：重写为全标签跳转的标准实现。

### 3. CI 隐患：BOM 被 workflow 抹掉
- `02-build.yml` 两处 `Set-Content` 在 pwsh 下默认 `utf8NoBOM`，会把 `.nsi` 的 BOM 抹掉，makensis 又按 CP1252 误读中文。改为 `Set-Content -Encoding utf8BOM`。

## 验证（本地 makensis 3.12 + UI 自动化实装实卸）

| 项 | 修复前 | 修复后 |
|---|---|---|
| 安装 | 卡死 94%，CPU 持续上涨 | 正常完成，CPU 0.56s |
| 组件页中文 | ANSI 依赖编译机代码页 | Unicode 正常渲染 |
| 注册表 DisplayName | 乱码 | 「ZedG — Zed 编辑器多语言版」 |
| PATH | 死循环前不写入 | 正确写入，卸载后移除 |
| 卸载 | 会卡同一死循环 | 100% 完成，全量还原 |