### PR TITLE
fix(deps): 钉住 openai<3.8，规避 3.8.0 并发翻译堆损坏

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ dependencies = [
 
 [project.optional-dependencies]
 excel = ["pandas>=2.0", "openpyxl>=3.1"]
-ai = ["openai>=1.0"]
+ai = ["openai>=1.0,<3.8"]
 all = ["zedl10n[excel,ai]"]
 
 [project.scripts]


### PR DESCRIPTION
## 现象
run 33834319301 (v1.18.0) 翻译到 205/1532 时 SIGABRT：`double free or corruption (!prev)`。

## 诊断
- 该 run **已包含** #53（tiktoken 已移除，安装列表确认无 tiktoken）→ tiktoken 不是（唯一）元凶
- 与上次成功 run (33794951236) 逐依赖对比，**唯一差异：openai 3.7.0 → 3.8.0**（pyproject 只约束 \，上游 3.8.0 发布后 CI 自动吃到）
- jiter/pydantic_core/httpx2/httpcore2 版本完全相同
- 佐证：上次成功 run 日志尾部已捕获 httpcore2 的 asyncgen 关闭 RuntimeError——openai HTTP 栈在新版本里有内存管理问题

## 修复
\ → \ 止血。上游修复后再放开。