### PR TITLE
fix(ci): macos-intel 设 RUST_MIN_STACK 缓解 rustc SIGSEGV

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -1670,6 +1670,9 @@ jobs:
       SCCACHE_DIR: /Users/runner/Library/Caches/Mozilla.sccache
       SCCACHE_IDLE_TIMEOUT: "0"
       BUILD_VERSION: ${{ needs.versioning.outputs.upstream_version }}
+      # Intel runner 上 rustc/LLVM AlwaysInliner 偶发 SIGSEGV（run 33834780189），
+      # rustc 官方建议增大线程栈（默认 8MB -> 16MB）
+      RUST_MIN_STACK: "16777216"
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## 现象
run 33834780189 仅 build-macos-x86_64 失败（其余 6 平台全绿）：rustc 1.97.1 编译 agent_servers crate 时 LLVM AlwaysInlinerPass 段错误，`rustc interrupted by SIGSEGV`，exit 101。

## 诊断
- 同代码 macos-aarch64 全绿 → 非代码缺陷，是 Intel runner 上 rustc/LLVM 的偶发问题
- 内存峰值 7.9GB / 14.3GB，未耗尽
- rustc 错误信息自带建议：\

## 修复
macos-intel job env 增加 RUST_MIN_STACK=16MB。合并后 rerun 失败 job 验证。