### PR TITLE
fix(ci): aarch64 补 lld 依赖修复链接失败

### DIFF
--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -2106,7 +2106,7 @@ jobs:
             libxcb-shape0-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-randr0-dev libxcb-keysyms1-dev libxcb-util-dev \
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
-            libssl-dev libudev-dev libclang-dev clang cmake mold rpm \
+            libssl-dev libudev-dev libclang-dev clang cmake mold lld rpm \
             patchelf libgit2-dev
           sudo ldconfig
           echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld -C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib" >> $GITHUB_ENV

--- a/.github/workflows/02-build.yml
+++ b/.github/workflows/02-build.yml
@@ -1118,7 +1118,7 @@ jobs:
             libxcb-shape0-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-randr0-dev libxcb-keysyms1-dev libxcb-util-dev \
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
-            libssl-dev libudev-dev libclang-dev clang cmake mold rpm \
+            libssl-dev libudev-dev libclang-dev clang cmake mold llvm rpm \
             patchelf libgit2-dev
           sudo ldconfig
           echo "RUSTFLAGS=-C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib/zedg" >> $GITHUB_ENV
@@ -2106,7 +2106,7 @@ jobs:
             libxcb-shape0-dev libxcb-xfixes0-dev libxcb-xinerama0-dev \
             libxcb-randr0-dev libxcb-keysyms1-dev libxcb-util-dev \
             libgl1-mesa-dev libegl1-mesa-dev libfreetype6-dev libfontconfig1-dev \
-            libssl-dev libudev-dev libclang-dev clang cmake mold lld rpm \
+            libssl-dev libudev-dev libclang-dev clang cmake mold lld llvm rpm \
             patchelf libgit2-dev
           sudo ldconfig
           echo "RUSTFLAGS=-C link-arg=-fuse-ld=lld -C link-args=-Wl,--disable-new-dtags,-rpath,\$ORIGIN/../lib" >> $GITHUB_ENV


### PR DESCRIPTION
PR #62 (issue #60 修复) 触发 run 34088633136 时 build-linux-aarch64 失败:

```
error: linking with cc failed: fatal error: cannot find 'ld'
```

根因: arm64 leg RUSTFLAGS 用 `-fuse-ld=lld` 但 apt 安装列表只装了 clang 没装 `lld` 包（无 /usr/bin/ld.lld），gcc collect2 找不到链接器。

修复: aarch64 apt 列表补 `lld`。